### PR TITLE
Add service label blacklisting to service actuator

### DIFF
--- a/cmd/remedy-controller-azure/app/app.go
+++ b/cmd/remedy-controller-azure/app/app.go
@@ -143,6 +143,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			virtualMachineCtrlOpts.Completed().Apply(&azurevirtualmachine.DefaultAddOptions.Controller)
 			configFileOpts.Completed().ApplyAzureFailedVMRemedy(&azurevirtualmachine.DefaultAddOptions.Config)
 			serviceCtrlOpts.Completed().Apply(&azureservice.DefaultAddOptions.Controller)
+			configFileOpts.Completed().ApplyAzureOrphanedPublicIPRemedy(&azureservice.DefaultAddOptions.Config)
 			nodeCtrlOpts.Completed().Apply(&azurenode.DefaultAddOptions.Controller)
 			reconcilerOpts.Completed().Apply(&azurepublicipaddress.DefaultAddOptions.InfraConfigPath)
 			reconcilerOpts.Completed().Apply(&azurevirtualmachine.DefaultAddOptions.InfraConfigPath)

--- a/example/00-config.yaml
+++ b/example/00-config.yaml
@@ -12,6 +12,10 @@ azure:
     deletionGracePeriod: 5m
     maxGetAttempts: 5
     maxCleanAttempts: 5
+#   blacklistedServiceLabels:
+#   - foo: bar
+#     bla: bla
+#   - one: more
   failedVMRemedy:
     requeueInterval: 1m
     maxGetAttempts: 5

--- a/hack/api-reference/config.md
+++ b/hack/api-reference/config.md
@@ -247,6 +247,18 @@ int
 <p>MaxCleanAttempts specifies the max attempts to clean an Azure public ip address.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>blacklistedServiceLabels</code></br>
+<em>
+[]map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>BlacklistedServiceLabels spcifies the labels of services that will be ignored.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <hr/>

--- a/pkg/apis/config/types.go
+++ b/pkg/apis/config/types.go
@@ -51,6 +51,8 @@ type AzureOrphanedPublicIPRemedyConfiguration struct {
 	MaxGetAttempts int
 	// MaxCleanAttempts specifies the max attempts to clean an Azure public ip address.
 	MaxCleanAttempts int
+	// BlacklistedServiceLabels spcifies the labels of services that will be ignored.
+	BlacklistedServiceLabels []map[string]string
 }
 
 // AzureFailedVMRemedyConfiguration defines the configuration for the Azure failed VM remedy.

--- a/pkg/apis/config/v1alpha1/types.go
+++ b/pkg/apis/config/v1alpha1/types.go
@@ -60,6 +60,9 @@ type AzureOrphanedPublicIPRemedyConfiguration struct {
 	// MaxCleanAttempts specifies the max attempts to clean an Azure public ip address.
 	// +optional
 	MaxCleanAttempts int `json:"maxCleanAttempts,omitempty"`
+	// BlacklistedServiceLabels spcifies the labels of services that will be ignored.
+	// +optional
+	BlacklistedServiceLabels []map[string]string `json:"blacklistedServiceLabels,omitempty"`
 }
 
 // AzureFailedVMRemedyConfiguration defines the configuration for the Azure failed VM remedy.

--- a/pkg/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.conversion.go
@@ -131,6 +131,7 @@ func autoConvert_v1alpha1_AzureOrphanedPublicIPRemedyConfiguration_To_config_Azu
 	out.DeletionGracePeriod = in.DeletionGracePeriod
 	out.MaxGetAttempts = in.MaxGetAttempts
 	out.MaxCleanAttempts = in.MaxCleanAttempts
+	out.BlacklistedServiceLabels = *(*[]map[string]string)(unsafe.Pointer(&in.BlacklistedServiceLabels))
 	return nil
 }
 
@@ -144,6 +145,7 @@ func autoConvert_config_AzureOrphanedPublicIPRemedyConfiguration_To_v1alpha1_Azu
 	out.DeletionGracePeriod = in.DeletionGracePeriod
 	out.MaxGetAttempts = in.MaxGetAttempts
 	out.MaxCleanAttempts = in.MaxCleanAttempts
+	out.BlacklistedServiceLabels = *(*[]map[string]string)(unsafe.Pointer(&in.BlacklistedServiceLabels))
 	return nil
 }
 

--- a/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -31,7 +31,7 @@ func (in *AzureConfiguration) DeepCopyInto(out *AzureConfiguration) {
 	if in.OrphanedPublicIPRemedy != nil {
 		in, out := &in.OrphanedPublicIPRemedy, &out.OrphanedPublicIPRemedy
 		*out = new(AzureOrphanedPublicIPRemedyConfiguration)
-		**out = **in
+		(*in).DeepCopyInto(*out)
 	}
 	if in.FailedVMRemedy != nil {
 		in, out := &in.FailedVMRemedy, &out.FailedVMRemedy
@@ -73,6 +73,19 @@ func (in *AzureOrphanedPublicIPRemedyConfiguration) DeepCopyInto(out *AzureOrpha
 	*out = *in
 	out.RequeueInterval = in.RequeueInterval
 	out.DeletionGracePeriod = in.DeletionGracePeriod
+	if in.BlacklistedServiceLabels != nil {
+		in, out := &in.BlacklistedServiceLabels, &out.BlacklistedServiceLabels
+		*out = make([]map[string]string, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = make(map[string]string, len(*in))
+				for key, val := range *in {
+					(*out)[key] = val
+				}
+			}
+		}
+	}
 	return
 }
 

--- a/pkg/apis/config/zz_generated.deepcopy.go
+++ b/pkg/apis/config/zz_generated.deepcopy.go
@@ -31,7 +31,7 @@ func (in *AzureConfiguration) DeepCopyInto(out *AzureConfiguration) {
 	if in.OrphanedPublicIPRemedy != nil {
 		in, out := &in.OrphanedPublicIPRemedy, &out.OrphanedPublicIPRemedy
 		*out = new(AzureOrphanedPublicIPRemedyConfiguration)
-		**out = **in
+		(*in).DeepCopyInto(*out)
 	}
 	if in.FailedVMRemedy != nil {
 		in, out := &in.FailedVMRemedy, &out.FailedVMRemedy
@@ -73,6 +73,19 @@ func (in *AzureOrphanedPublicIPRemedyConfiguration) DeepCopyInto(out *AzureOrpha
 	*out = *in
 	out.RequeueInterval = in.RequeueInterval
 	out.DeletionGracePeriod = in.DeletionGracePeriod
+	if in.BlacklistedServiceLabels != nil {
+		in, out := &in.BlacklistedServiceLabels, &out.BlacklistedServiceLabels
+		*out = make([]map[string]string, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = make(map[string]string, len(*in))
+				for key, val := range *in {
+					(*out)[key] = val
+				}
+			}
+		}
+	}
 	return
 }
 

--- a/pkg/controller/azure/service/add.go
+++ b/pkg/controller/azure/service/add.go
@@ -15,6 +15,7 @@
 package service
 
 import (
+	"github.com/gardener/remedy-controller/pkg/apis/config"
 	remedycontroller "github.com/gardener/remedy-controller/pkg/controller"
 
 	corev1 "k8s.io/api/core/v1"
@@ -45,12 +46,14 @@ type AddOptions struct {
 	Client client.Client
 	// Namespace is the namespace for custom resources in the control cluster.
 	Namespace string
+	// Config is the configuration for the Azure orphaned public IP remedy.
+	Config config.AzureOrphanedPublicIPRemedyConfiguration
 }
 
 // AddToManagerWithOptions adds a controller with the given AddOptions to the given manager.
 func AddToManagerWithOptions(mgr manager.Manager, options AddOptions) error {
 	return remedycontroller.Add(mgr, remedycontroller.AddArgs{
-		Actuator:          NewActuator(options.Client, options.Namespace, log.Log.WithName(ActuatorName)),
+		Actuator:          NewActuator(options.Client, options.Config, options.Namespace, log.Log.WithName(ActuatorName)),
 		ControllerName:    ControllerName,
 		FinalizerName:     FinalizerName,
 		ControllerOptions: options.Controller,


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows the remedy controller to ignore services based on their labels.

**Which issue(s) this PR fixes**:
Fixes #12 
