### PR TITLE
Fix double reconciliation by virtualmachine controller

### DIFF
--- a/example/00-config.yaml
+++ b/example/00-config.yaml
@@ -13,6 +13,6 @@ azure:
     maxGetAttempts: 5
     maxCleanAttempts: 5
   failedVMRemedy:
-    requeueInterval: 1m
+    requeueInterval: 30s
     maxGetAttempts: 5
-    maxReapplyAttempts: 5
+    maxReapplyAttempts: 3

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -180,24 +180,13 @@ string
 </tr>
 <tr>
 <td>
-<code>ready</code></br>
+<code>notReadyOrUnreachable</code></br>
 <em>
 bool
 </em>
 </td>
 <td>
-<p>Ready is whether the Kubernetes node for this virtual machine is ready.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>unreachable</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>Unreachable is whether the Kubernetes node for this virtual machine is unreachable.</p>
+<p>NotReadyOrUnreachable is whether the Kubernetes node for this virtual machine is either not ready or unreachable.</p>
 </td>
 </tr>
 </table>
@@ -441,24 +430,13 @@ string
 </tr>
 <tr>
 <td>
-<code>ready</code></br>
+<code>notReadyOrUnreachable</code></br>
 <em>
 bool
 </em>
 </td>
 <td>
-<p>Ready is whether the Kubernetes node for this virtual machine is ready.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>unreachable</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>Unreachable is whether the Kubernetes node for this virtual machine is unreachable.</p>
+<p>NotReadyOrUnreachable is whether the Kubernetes node for this virtual machine is either not ready or unreachable.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/azure/types_virtualmachine.go
+++ b/pkg/apis/azure/types_virtualmachine.go
@@ -35,10 +35,8 @@ type VirtualMachineSpec struct {
 	Hostname string
 	// ProviderID is the provider ID of the Kubernetes node for this virtual machine.
 	ProviderID string
-	// Ready is whether the Kubernetes node for this virtual machine is ready.
-	Ready bool
-	// Unreachable is whether the Kubernetes node for this virtual machine is unreachable.
-	Unreachable bool
+	// NotReadyOrUnreachable is whether the Kubernetes node for this virtual machine is either not ready or unreachable.
+	NotReadyOrUnreachable bool
 }
 
 // VirtualMachineStatus represents the status of an Azure virtual machine.

--- a/pkg/apis/azure/v1alpha1/types_virtualmachine.go
+++ b/pkg/apis/azure/v1alpha1/types_virtualmachine.go
@@ -36,10 +36,8 @@ type VirtualMachineSpec struct {
 	Hostname string `json:"hostname"`
 	// ProviderID is the provider ID of the Kubernetes node for this virtual machine.
 	ProviderID string `json:"providerID"`
-	// Ready is whether the Kubernetes node for this virtual machine is ready.
-	Ready bool `json:"ready"`
-	// Unreachable is whether the Kubernetes node for this virtual machine is unreachable.
-	Unreachable bool `json:"unreachable"`
+	// NotReadyOrUnreachable is whether the Kubernetes node for this virtual machine is either not ready or unreachable.
+	NotReadyOrUnreachable bool `json:"notReadyOrUnreachable"`
 }
 
 // VirtualMachineStatus represents the status of an Azure virtual machine.

--- a/pkg/apis/azure/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/azure/v1alpha1/zz_generated.conversion.go
@@ -313,8 +313,7 @@ func Convert_azure_VirtualMachineList_To_v1alpha1_VirtualMachineList(in *azure.V
 func autoConvert_v1alpha1_VirtualMachineSpec_To_azure_VirtualMachineSpec(in *VirtualMachineSpec, out *azure.VirtualMachineSpec, s conversion.Scope) error {
 	out.Hostname = in.Hostname
 	out.ProviderID = in.ProviderID
-	out.Ready = in.Ready
-	out.Unreachable = in.Unreachable
+	out.NotReadyOrUnreachable = in.NotReadyOrUnreachable
 	return nil
 }
 
@@ -326,8 +325,7 @@ func Convert_v1alpha1_VirtualMachineSpec_To_azure_VirtualMachineSpec(in *Virtual
 func autoConvert_azure_VirtualMachineSpec_To_v1alpha1_VirtualMachineSpec(in *azure.VirtualMachineSpec, out *VirtualMachineSpec, s conversion.Scope) error {
 	out.Hostname = in.Hostname
 	out.ProviderID = in.ProviderID
-	out.Ready = in.Ready
-	out.Unreachable = in.Unreachable
+	out.NotReadyOrUnreachable = in.NotReadyOrUnreachable
 	return nil
 }
 

--- a/pkg/controller/azure/node/actuator.go
+++ b/pkg/controller/azure/node/actuator.go
@@ -73,8 +73,7 @@ func (a *actuator) CreateOrUpdate(ctx context.Context, obj runtime.Object) (requ
 	// Get node properties
 	hostname := node.Labels[HostnameLabel]
 	providerID := node.Spec.ProviderID
-	ready := isNodeReady(node)
-	unreachable := isNodeUnreachable(node)
+	notReadyOrUnreachable := !isNodeReady(node) || isNodeUnreachable(node)
 
 	// Create or update the VirtualMachine object for the node
 	vm := &azurev1alpha1.VirtualMachine{
@@ -89,8 +88,7 @@ func (a *actuator) CreateOrUpdate(ctx context.Context, obj runtime.Object) (requ
 			vm.Labels = vmLabels
 			vm.Spec.Hostname = hostname
 			vm.Spec.ProviderID = providerID
-			vm.Spec.Ready = ready
-			vm.Spec.Unreachable = unreachable
+			vm.Spec.NotReadyOrUnreachable = notReadyOrUnreachable
 			return nil
 		})
 		return err

--- a/pkg/controller/azure/node/actuator_test.go
+++ b/pkg/controller/azure/node/actuator_test.go
@@ -103,10 +103,9 @@ var _ = Describe("Actuator", func() {
 				Labels:    vmLabels,
 			},
 			Spec: azurev1alpha1.VirtualMachineSpec{
-				Hostname:    hostname,
-				ProviderID:  providerID,
-				Ready:       true,
-				Unreachable: false,
+				Hostname:              hostname,
+				ProviderID:            providerID,
+				NotReadyOrUnreachable: false,
 			},
 		}
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue with double reconciliation by the virtualmachine controller that lead to higher number of reapply attempts than expected. The reason for the issue was that when a VM becomes `Failed`, its node is updated twice (once for not being ready, and another time for becoming unreachable), so the virtualmachine object is also updated twice (since `ready`  and `unreachable` are 2 separate fields in the spec), and this triggers 2 chains of reconciliations, each essentially with their own value of the attempts counter (because the events get generated before the counter is updated).

To fix the issue, I combined the 2 fields `ready` and `unreachable` into a single one `notReadyOrUnreachable`, so the virtualmachine object is only updated once.

**Special notes for your reviewer**:

**Release note**:
```improvement operator
NONE
```
