### PR TITLE
Revert service blacklisting, add service ignore annotation

### DIFF
--- a/cmd/remedy-controller-azure/app/app.go
+++ b/cmd/remedy-controller-azure/app/app.go
@@ -143,7 +143,6 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			virtualMachineCtrlOpts.Completed().Apply(&azurevirtualmachine.DefaultAddOptions.Controller)
 			configFileOpts.Completed().ApplyAzureFailedVMRemedy(&azurevirtualmachine.DefaultAddOptions.Config)
 			serviceCtrlOpts.Completed().Apply(&azureservice.DefaultAddOptions.Controller)
-			configFileOpts.Completed().ApplyAzureOrphanedPublicIPRemedy(&azureservice.DefaultAddOptions.Config)
 			nodeCtrlOpts.Completed().Apply(&azurenode.DefaultAddOptions.Controller)
 			reconcilerOpts.Completed().Apply(&azurepublicipaddress.DefaultAddOptions.InfraConfigPath)
 			reconcilerOpts.Completed().Apply(&azurevirtualmachine.DefaultAddOptions.InfraConfigPath)

--- a/example/00-config.yaml
+++ b/example/00-config.yaml
@@ -12,10 +12,6 @@ azure:
     deletionGracePeriod: 5m
     maxGetAttempts: 5
     maxCleanAttempts: 5
-#   blacklistedServiceLabels:
-#   - foo: bar
-#     bla: bla
-#   - one: more
   failedVMRemedy:
     requeueInterval: 30s
     maxGetAttempts: 5

--- a/hack/api-reference/config.md
+++ b/hack/api-reference/config.md
@@ -247,18 +247,6 @@ int
 <p>MaxCleanAttempts specifies the max attempts to clean an Azure public ip address.</p>
 </td>
 </tr>
-<tr>
-<td>
-<code>blacklistedServiceLabels</code></br>
-<em>
-[]map[string]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>BlacklistedServiceLabels spcifies the labels of services that will be ignored.</p>
-</td>
-</tr>
 </tbody>
 </table>
 <hr/>

--- a/pkg/apis/config/types.go
+++ b/pkg/apis/config/types.go
@@ -51,8 +51,6 @@ type AzureOrphanedPublicIPRemedyConfiguration struct {
 	MaxGetAttempts int
 	// MaxCleanAttempts specifies the max attempts to clean an Azure public ip address.
 	MaxCleanAttempts int
-	// BlacklistedServiceLabels spcifies the labels of services that will be ignored.
-	BlacklistedServiceLabels []map[string]string
 }
 
 // AzureFailedVMRemedyConfiguration defines the configuration for the Azure failed VM remedy.

--- a/pkg/apis/config/v1alpha1/types.go
+++ b/pkg/apis/config/v1alpha1/types.go
@@ -60,9 +60,6 @@ type AzureOrphanedPublicIPRemedyConfiguration struct {
 	// MaxCleanAttempts specifies the max attempts to clean an Azure public ip address.
 	// +optional
 	MaxCleanAttempts int `json:"maxCleanAttempts,omitempty"`
-	// BlacklistedServiceLabels spcifies the labels of services that will be ignored.
-	// +optional
-	BlacklistedServiceLabels []map[string]string `json:"blacklistedServiceLabels,omitempty"`
 }
 
 // AzureFailedVMRemedyConfiguration defines the configuration for the Azure failed VM remedy.

--- a/pkg/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.conversion.go
@@ -131,7 +131,6 @@ func autoConvert_v1alpha1_AzureOrphanedPublicIPRemedyConfiguration_To_config_Azu
 	out.DeletionGracePeriod = in.DeletionGracePeriod
 	out.MaxGetAttempts = in.MaxGetAttempts
 	out.MaxCleanAttempts = in.MaxCleanAttempts
-	out.BlacklistedServiceLabels = *(*[]map[string]string)(unsafe.Pointer(&in.BlacklistedServiceLabels))
 	return nil
 }
 
@@ -145,7 +144,6 @@ func autoConvert_config_AzureOrphanedPublicIPRemedyConfiguration_To_v1alpha1_Azu
 	out.DeletionGracePeriod = in.DeletionGracePeriod
 	out.MaxGetAttempts = in.MaxGetAttempts
 	out.MaxCleanAttempts = in.MaxCleanAttempts
-	out.BlacklistedServiceLabels = *(*[]map[string]string)(unsafe.Pointer(&in.BlacklistedServiceLabels))
 	return nil
 }
 

--- a/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -31,7 +31,7 @@ func (in *AzureConfiguration) DeepCopyInto(out *AzureConfiguration) {
 	if in.OrphanedPublicIPRemedy != nil {
 		in, out := &in.OrphanedPublicIPRemedy, &out.OrphanedPublicIPRemedy
 		*out = new(AzureOrphanedPublicIPRemedyConfiguration)
-		(*in).DeepCopyInto(*out)
+		**out = **in
 	}
 	if in.FailedVMRemedy != nil {
 		in, out := &in.FailedVMRemedy, &out.FailedVMRemedy
@@ -73,19 +73,6 @@ func (in *AzureOrphanedPublicIPRemedyConfiguration) DeepCopyInto(out *AzureOrpha
 	*out = *in
 	out.RequeueInterval = in.RequeueInterval
 	out.DeletionGracePeriod = in.DeletionGracePeriod
-	if in.BlacklistedServiceLabels != nil {
-		in, out := &in.BlacklistedServiceLabels, &out.BlacklistedServiceLabels
-		*out = make([]map[string]string, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = make(map[string]string, len(*in))
-				for key, val := range *in {
-					(*out)[key] = val
-				}
-			}
-		}
-	}
 	return
 }
 

--- a/pkg/apis/config/zz_generated.deepcopy.go
+++ b/pkg/apis/config/zz_generated.deepcopy.go
@@ -31,7 +31,7 @@ func (in *AzureConfiguration) DeepCopyInto(out *AzureConfiguration) {
 	if in.OrphanedPublicIPRemedy != nil {
 		in, out := &in.OrphanedPublicIPRemedy, &out.OrphanedPublicIPRemedy
 		*out = new(AzureOrphanedPublicIPRemedyConfiguration)
-		(*in).DeepCopyInto(*out)
+		**out = **in
 	}
 	if in.FailedVMRemedy != nil {
 		in, out := &in.FailedVMRemedy, &out.FailedVMRemedy
@@ -73,19 +73,6 @@ func (in *AzureOrphanedPublicIPRemedyConfiguration) DeepCopyInto(out *AzureOrpha
 	*out = *in
 	out.RequeueInterval = in.RequeueInterval
 	out.DeletionGracePeriod = in.DeletionGracePeriod
-	if in.BlacklistedServiceLabels != nil {
-		in, out := &in.BlacklistedServiceLabels, &out.BlacklistedServiceLabels
-		*out = make([]map[string]string, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = make(map[string]string, len(*in))
-				for key, val := range *in {
-					(*out)[key] = val
-				}
-			}
-		}
-	}
 	return
 }
 

--- a/pkg/controller/azure/service/add.go
+++ b/pkg/controller/azure/service/add.go
@@ -15,7 +15,6 @@
 package service
 
 import (
-	"github.com/gardener/remedy-controller/pkg/apis/config"
 	remedycontroller "github.com/gardener/remedy-controller/pkg/controller"
 
 	corev1 "k8s.io/api/core/v1"
@@ -46,14 +45,12 @@ type AddOptions struct {
 	Client client.Client
 	// Namespace is the namespace for custom resources in the control cluster.
 	Namespace string
-	// Config is the configuration for the Azure orphaned public IP remedy.
-	Config config.AzureOrphanedPublicIPRemedyConfiguration
 }
 
 // AddToManagerWithOptions adds a controller with the given AddOptions to the given manager.
 func AddToManagerWithOptions(mgr manager.Manager, options AddOptions) error {
 	return remedycontroller.Add(mgr, remedycontroller.AddArgs{
-		Actuator:          NewActuator(options.Client, options.Config, options.Namespace, log.Log.WithName(ActuatorName)),
+		Actuator:          NewActuator(options.Client, options.Namespace, log.Log.WithName(ActuatorName)),
 		ControllerName:    ControllerName,
 		FinalizerName:     FinalizerName,
 		ControllerOptions: options.Controller,

--- a/pkg/controller/azure/service/predicate.go
+++ b/pkg/controller/azure/service/predicate.go
@@ -61,6 +61,10 @@ func NewLoadBalancerIPsChangedPredicate(logger logr.Logger) predicate.Predicate 
 				logger.Info("Updating the deletion timestamp of a service with LoadBalancer IPs")
 				return true
 			}
+			if len(newIPs) > 0 && shouldIgnoreService(oldService) != shouldIgnoreService(newService) {
+				logger.Info("Updating the ignore annotation of a service with LoadBalancer IPs")
+				return true
+			}
 			if !reflect.DeepEqual(oldIPs, newIPs) {
 				logger.Info("Updating service LoadBalancer IPs")
 				return true

--- a/pkg/utils/map.go
+++ b/pkg/utils/map.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company.All rights reserved.This file is licensed under the Apache Software License, v.2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+func Add(m map[string]string, key, value string) map[string]string {
+	if m == nil {
+		m = make(map[string]string)
+	}
+	m[key] = value
+	return m
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
* Reverts blacklisting of services based on labels introduced with #20
* Introduce an annotation that, if added to a service, makes the service controller ignore the public IP addresses of that service. Adding or removing this annotation has the effect of deleting / re-creating the corresponding `publicipaddress` objects and removing / re-adding the finalizer on a service (but without cleaning the IP when deleting).
* Add unit tests for the new annotation.
* Refactor tests for the `publicipaddress` actuator.

**Which issue(s) this PR fixes**:
Fixes #12 

**Special notes for your reviewer**:

**Release note**:
```improvement operator
NONE
```
