### PR TITLE
Enhance handling of finalizers by the generic reconciler

### DIFF
--- a/pkg/controller/azure/node/actuator.go
+++ b/pkg/controller/azure/node/actuator.go
@@ -57,12 +57,12 @@ func NewActuator(client client.Client, namespace string, logger logr.Logger) con
 }
 
 // CreateOrUpdate reconciles object creation or update.
-func (a *actuator) CreateOrUpdate(ctx context.Context, obj runtime.Object) (requeueAfter time.Duration, removeFinalizer bool, err error) {
+func (a *actuator) CreateOrUpdate(ctx context.Context, obj runtime.Object) (requeueAfter time.Duration, err error) {
 	// Cast object to Node
 	var node *corev1.Node
 	var ok bool
 	if node, ok = obj.(*corev1.Node); !ok {
-		return 0, false, errors.New("reconciled object is not a node")
+		return 0, errors.New("reconciled object is not a node")
 	}
 
 	// Initialize labels
@@ -93,10 +93,10 @@ func (a *actuator) CreateOrUpdate(ctx context.Context, obj runtime.Object) (requ
 		})
 		return err
 	}); err != nil {
-		return 0, false, errors.Wrap(err, "could not create or update virtualmachine")
+		return 0, errors.Wrap(err, "could not create or update virtualmachine")
 	}
 
-	return 0, false, nil
+	return 0, nil
 }
 
 // Delete reconciles object deletion.
@@ -121,6 +121,11 @@ func (a *actuator) Delete(ctx context.Context, obj runtime.Object) error {
 	}
 
 	return nil
+}
+
+// ShouldFinalize returns true if the object should be finalized.
+func (a *actuator) ShouldFinalize(_ context.Context, _ runtime.Object) (bool, error) {
+	return true, nil
 }
 
 func isNodeReady(node *corev1.Node) bool {

--- a/pkg/controller/azure/node/actuator_test.go
+++ b/pkg/controller/azure/node/actuator_test.go
@@ -120,10 +120,9 @@ var _ = Describe("Actuator", func() {
 				Return(apierrors.NewNotFound(schema.GroupResource{}, vm.Name))
 			c.EXPECT().Create(ctx, vm).Return(nil)
 
-			requeueAfter, removeFinalizer, err := actuator.CreateOrUpdate(ctx, node)
+			requeueAfter, err := actuator.CreateOrUpdate(ctx, node)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(requeueAfter).To(Equal(time.Duration(0)))
-			Expect(removeFinalizer).To(Equal(false))
 		})
 
 		It("should fail when creating the VirtualMachine object for a node and an error occurs", func() {
@@ -131,7 +130,7 @@ var _ = Describe("Actuator", func() {
 				Return(apierrors.NewNotFound(schema.GroupResource{}, vm.Name))
 			c.EXPECT().Create(ctx, vm).Return(apierrors.NewInternalError(errors.New("test")))
 
-			_, _, err := actuator.CreateOrUpdate(ctx, node)
+			_, err := actuator.CreateOrUpdate(ctx, node)
 			Expect(err).To(MatchError("could not create or update virtualmachine: Internal error occurred: test"))
 		})
 
@@ -143,10 +142,9 @@ var _ = Describe("Actuator", func() {
 				})
 			c.EXPECT().Update(ctx, vm).Return(nil)
 
-			requeueAfter, removeFinalizer, err := actuator.CreateOrUpdate(ctx, node)
+			requeueAfter, err := actuator.CreateOrUpdate(ctx, node)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(requeueAfter).To(Equal(time.Duration(0)))
-			Expect(removeFinalizer).To(Equal(false))
 		})
 
 		It("should not update the VirtualMachine object for a node if it already exists and is properly initialized", func() {
@@ -156,10 +154,9 @@ var _ = Describe("Actuator", func() {
 					return nil
 				})
 
-			requeueAfter, removeFinalizer, err := actuator.CreateOrUpdate(ctx, node)
+			requeueAfter, err := actuator.CreateOrUpdate(ctx, node)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(requeueAfter).To(Equal(time.Duration(0)))
-			Expect(removeFinalizer).To(Equal(false))
 		})
 
 		It("should retry when updating the VirtualMachine object for a node and a Conflict error occurs", func() {
@@ -176,10 +173,9 @@ var _ = Describe("Actuator", func() {
 				})
 			c.EXPECT().Update(ctx, vm).Return(nil)
 
-			requeueAfter, removeFinalizer, err := actuator.CreateOrUpdate(ctx, node)
+			requeueAfter, err := actuator.CreateOrUpdate(ctx, node)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(requeueAfter).To(Equal(time.Duration(0)))
-			Expect(removeFinalizer).To(Equal(false))
 		})
 
 		It("should fail when updating the VirtualMachine object for a node and an error different from Conflict occurs", func() {
@@ -190,7 +186,7 @@ var _ = Describe("Actuator", func() {
 				})
 			c.EXPECT().Update(ctx, vm).Return(apierrors.NewInternalError(errors.New("test")))
 
-			_, _, err := actuator.CreateOrUpdate(ctx, node)
+			_, err := actuator.CreateOrUpdate(ctx, node)
 			Expect(err).To(MatchError("could not create or update virtualmachine: Internal error occurred: test"))
 		})
 	})

--- a/pkg/controller/azure/publicipaddress/actuator_test.go
+++ b/pkg/controller/azure/publicipaddress/actuator_test.go
@@ -155,10 +155,9 @@ var _ = Describe("Actuator", func() {
 			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: pubip.Namespace, Name: pubip.Name}, pubip).Return(nil)
 			sw.EXPECT().Update(ctx, pubipWithStatus).Return(nil)
 
-			requeueAfter, removeFinalizer, err := actuator.CreateOrUpdate(ctx, pubip)
+			requeueAfter, err := actuator.CreateOrUpdate(ctx, pubip)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(requeueAfter).To(Equal(time.Duration(0)))
-			Expect(removeFinalizer).To(Equal(false))
 		})
 
 		It("should not update the PublicIPAddress object status if the IP is not found", func() {
@@ -166,10 +165,9 @@ var _ = Describe("Actuator", func() {
 			pubipUtils.EXPECT().GetByIP(ctx, ip).Return(nil, nil)
 			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: pubip.Namespace, Name: pubip.Name}, pubip).Return(nil)
 
-			requeueAfter, removeFinalizer, err := actuator.CreateOrUpdate(ctx, pubip)
+			requeueAfter, err := actuator.CreateOrUpdate(ctx, pubip)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(requeueAfter).To(Equal(requeueInterval))
-			Expect(removeFinalizer).To(Equal(false))
 		})
 
 		It("should not update the PublicIPAddress object status if the IP is found and the status is already initialized", func() {
@@ -177,10 +175,9 @@ var _ = Describe("Actuator", func() {
 			pubipUtils.EXPECT().GetByName(ctx, azurePublicIPAddressName).Return(azurePublicIPAddress, nil)
 			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: pubipWithStatus.Namespace, Name: pubipWithStatus.Name}, pubipWithStatus).Return(nil)
 
-			requeueAfter, removeFinalizer, err := actuator.CreateOrUpdate(ctx, pubipWithStatus)
+			requeueAfter, err := actuator.CreateOrUpdate(ctx, pubipWithStatus)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(requeueAfter).To(Equal(time.Duration(0)))
-			Expect(removeFinalizer).To(Equal(false))
 		})
 
 		It("should update the PublicIPAddress object status if the IP is not found and the status is already initialized", func() {
@@ -189,10 +186,9 @@ var _ = Describe("Actuator", func() {
 			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: pubipWithStatus.Namespace, Name: pubipWithStatus.Name}, pubipWithStatus).Return(nil)
 			sw.EXPECT().Update(ctx, pubip).Return(nil)
 
-			requeueAfter, removeFinalizer, err := actuator.CreateOrUpdate(ctx, pubipWithStatus)
+			requeueAfter, err := actuator.CreateOrUpdate(ctx, pubipWithStatus)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(requeueAfter).To(Equal(requeueInterval))
-			Expect(removeFinalizer).To(Equal(false))
 		})
 
 		It("should fail and requeue if getting the Azure IP address by IP fails", func() {
@@ -203,7 +199,7 @@ var _ = Describe("Actuator", func() {
 			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: pubip.Namespace, Name: pubip.Name}, pubip).Return(nil)
 			sw.EXPECT().Update(ctx, pubipWithFailedOps).Return(nil)
 
-			_, _, err := actuator.CreateOrUpdate(ctx, pubip)
+			_, err := actuator.CreateOrUpdate(ctx, pubip)
 			Expect(err).To(BeAssignableToTypeOf(&controllererror.RequeueAfterError{}))
 			re := err.(*controllererror.RequeueAfterError)
 			Expect(re.Cause).To(MatchError("could not get Azure public IP address by IP: test"))
@@ -228,7 +224,7 @@ var _ = Describe("Actuator", func() {
 			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: pubip.Namespace, Name: pubip.Name}, pubip).Return(nil)
 			sw.EXPECT().Update(ctx, pubipWithStatus).Return(errors.New("test"))
 
-			_, _, err := actuator.CreateOrUpdate(ctx, pubip)
+			_, err := actuator.CreateOrUpdate(ctx, pubip)
 			Expect(err).To(MatchError("could not update publicipaddress status: test"))
 		})
 	})

--- a/pkg/controller/azure/service/actuator_test.go
+++ b/pkg/controller/azure/service/actuator_test.go
@@ -167,10 +167,9 @@ var _ = Describe("Actuator", func() {
 					return nil
 				})
 
-			requeueAfter, removeFinalizer, err := actuator.CreateOrUpdate(ctx, svc)
+			requeueAfter, err := actuator.CreateOrUpdate(ctx, svc)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(requeueAfter).To(Equal(time.Duration(0)))
-			Expect(removeFinalizer).To(Equal(false))
 		})
 
 		It("should fail when creating the PublicIPAddress object for a service of type LoadBalancer and an error occurs", func() {
@@ -178,7 +177,7 @@ var _ = Describe("Actuator", func() {
 				Return(apierrors.NewNotFound(schema.GroupResource{}, pubip.Name))
 			c.EXPECT().Create(ctx, pubip).Return(apierrors.NewInternalError(errors.New("test")))
 
-			_, _, err := actuator.CreateOrUpdate(ctx, svc)
+			_, err := actuator.CreateOrUpdate(ctx, svc)
 			Expect(err).To(MatchError("could not create or update publicipaddress: Internal error occurred: test"))
 		})
 
@@ -189,7 +188,7 @@ var _ = Describe("Actuator", func() {
 			c.EXPECT().List(ctx, &azurev1alpha1.PublicIPAddressList{}, client.InNamespace(namespace), client.MatchingLabels(pubipLabels)).
 				Return(apierrors.NewInternalError(errors.New("test")))
 
-			_, _, err := actuator.CreateOrUpdate(ctx, svc)
+			_, err := actuator.CreateOrUpdate(ctx, svc)
 			Expect(err).To(MatchError("could not list publicipaddresses: Internal error occurred: test"))
 		})
 
@@ -206,10 +205,9 @@ var _ = Describe("Actuator", func() {
 					return nil
 				})
 
-			requeueAfter, removeFinalizer, err := actuator.CreateOrUpdate(ctx, svc)
+			requeueAfter, err := actuator.CreateOrUpdate(ctx, svc)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(requeueAfter).To(Equal(time.Duration(0)))
-			Expect(removeFinalizer).To(Equal(false))
 		})
 
 		It("should not update the PublicIPAddress object for a service of type LoadBalancer if it already exists and is properly initialized", func() {
@@ -224,10 +222,9 @@ var _ = Describe("Actuator", func() {
 					return nil
 				})
 
-			requeueAfter, removeFinalizer, err := actuator.CreateOrUpdate(ctx, svc)
+			requeueAfter, err := actuator.CreateOrUpdate(ctx, svc)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(requeueAfter).To(Equal(time.Duration(0)))
-			Expect(removeFinalizer).To(Equal(false))
 		})
 
 		It("should retry when updating the PublicIPAddress object for a service of type LoadBalancer and a Conflict error occurs", func() {
@@ -249,10 +246,9 @@ var _ = Describe("Actuator", func() {
 					return nil
 				})
 
-			requeueAfter, removeFinalizer, err := actuator.CreateOrUpdate(ctx, svc)
+			requeueAfter, err := actuator.CreateOrUpdate(ctx, svc)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(requeueAfter).To(Equal(time.Duration(0)))
-			Expect(removeFinalizer).To(Equal(false))
 		})
 
 		It("should fail when updating the PublicIPAddress object for a service of type LoadBalancer and an error different from Conflict occurs", func() {
@@ -263,7 +259,7 @@ var _ = Describe("Actuator", func() {
 				})
 			c.EXPECT().Update(ctx, pubip).Return(apierrors.NewInternalError(errors.New("test")))
 
-			_, _, err := actuator.CreateOrUpdate(ctx, svc)
+			_, err := actuator.CreateOrUpdate(ctx, svc)
 			Expect(err).To(MatchError("could not create or update publicipaddress: Internal error occurred: test"))
 		})
 
@@ -274,10 +270,9 @@ var _ = Describe("Actuator", func() {
 					return nil
 				})
 
-			requeueAfter, removeFinalizer, err := actuator.CreateOrUpdate(ctx, clusterIPSvc)
+			requeueAfter, err := actuator.CreateOrUpdate(ctx, clusterIPSvc)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(requeueAfter).To(Equal(time.Duration(0)))
-			Expect(removeFinalizer).To(Equal(true))
 		})
 
 		It("should delete the PublicIPAddress object for a service of type ClusterIP if it already exists", func() {
@@ -288,10 +283,9 @@ var _ = Describe("Actuator", func() {
 				})
 			c.EXPECT().Delete(ctx, pubip).Return(nil)
 
-			requeueAfter, removeFinalizer, err := actuator.CreateOrUpdate(ctx, clusterIPSvc)
+			requeueAfter, err := actuator.CreateOrUpdate(ctx, clusterIPSvc)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(requeueAfter).To(Equal(time.Duration(0)))
-			Expect(removeFinalizer).To(Equal(true))
 		})
 
 		It("should succeed when deleting the PublicIPAddress object for a service of type ClusterIP and a NotFound error occurs", func() {
@@ -302,10 +296,9 @@ var _ = Describe("Actuator", func() {
 				})
 			c.EXPECT().Delete(ctx, pubip).Return(apierrors.NewNotFound(schema.GroupResource{}, pubip.Name))
 
-			requeueAfter, removeFinalizer, err := actuator.CreateOrUpdate(ctx, clusterIPSvc)
+			requeueAfter, err := actuator.CreateOrUpdate(ctx, clusterIPSvc)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(requeueAfter).To(Equal(time.Duration(0)))
-			Expect(removeFinalizer).To(Equal(true))
 		})
 
 		It("should fail when deleting the PublicIPAddress object for a service of type ClusterIP and an error different from NotFound occurs", func() {
@@ -316,7 +309,7 @@ var _ = Describe("Actuator", func() {
 				})
 			c.EXPECT().Delete(ctx, pubip).Return(apierrors.NewInternalError(errors.New("test")))
 
-			_, _, err := actuator.CreateOrUpdate(ctx, clusterIPSvc)
+			_, err := actuator.CreateOrUpdate(ctx, clusterIPSvc)
 			Expect(err).To(MatchError("could not delete publicipaddress: Internal error occurred: test"))
 		})
 
@@ -327,10 +320,9 @@ var _ = Describe("Actuator", func() {
 					return nil
 				})
 
-			requeueAfter, removeFinalizer, err := actuator.CreateOrUpdate(ctx, ignoredSvc)
+			requeueAfter, err := actuator.CreateOrUpdate(ctx, ignoredSvc)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(requeueAfter).To(Equal(time.Duration(0)))
-			Expect(removeFinalizer).To(Equal(true))
 		})
 
 		It("should add the do-not-clean annotation and then delete the PublicIPAddress object for a service of type LoadBalancer that has the ignore annotation if it already exists", func() {
@@ -342,10 +334,9 @@ var _ = Describe("Actuator", func() {
 			c.EXPECT().Update(ctx, annotatedPubip).Return(nil)
 			c.EXPECT().Delete(ctx, annotatedPubip).Return(nil)
 
-			requeueAfter, removeFinalizer, err := actuator.CreateOrUpdate(ctx, ignoredSvc)
+			requeueAfter, err := actuator.CreateOrUpdate(ctx, ignoredSvc)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(requeueAfter).To(Equal(time.Duration(0)))
-			Expect(removeFinalizer).To(Equal(true))
 		})
 	})
 
@@ -371,6 +362,26 @@ var _ = Describe("Actuator", func() {
 
 		It("should do nothing for a service of type ClusterIP", func() {
 			Expect(actuator.Delete(ctx, clusterIPSvc)).To(Succeed())
+		})
+	})
+
+	Describe("#ShouldFinalize", func() {
+		It("should return true for a service of type LoadBalancer", func() {
+			shouldFinalize, err := actuator.ShouldFinalize(ctx, svc)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldFinalize).To(BeTrue())
+		})
+
+		It("should return false for a service of type ClusterIP", func() {
+			shouldFinalize, err := actuator.ShouldFinalize(ctx, clusterIPSvc)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldFinalize).To(BeFalse())
+		})
+
+		It("should return false for a service of type LoadBalancer that has the ignore annotation", func() {
+			shouldFinalize, err := actuator.ShouldFinalize(ctx, ignoredSvc)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldFinalize).To(BeFalse())
 		})
 	})
 })

--- a/pkg/controller/azure/service/predicate.go
+++ b/pkg/controller/azure/service/predicate.go
@@ -30,17 +30,11 @@ func NewLoadBalancerIPsChangedPredicate(logger logr.Logger) predicate.Predicate 
 				logger.Error(nil, "CreateEvent has no object", "event", e)
 				return false
 			}
-			var service *corev1.Service
-			var ok bool
-			if service, ok = e.Object.(*corev1.Service); !ok {
+			if _, ok := e.Object.(*corev1.Service); !ok {
 				return false
 			}
-			ips := getServiceLoadBalancerIPs(service)
-			if len(ips) > 0 {
-				logger.Info("Creating a service with LoadBalancer IPs")
-				return true
-			}
-			return false
+			logger.Info("Creating a service")
+			return true
 		},
 
 		UpdateFunc: func(e event.UpdateEvent) bool {
@@ -77,17 +71,11 @@ func NewLoadBalancerIPsChangedPredicate(logger logr.Logger) predicate.Predicate 
 				logger.Error(nil, "DeleteEvent has no object", "event", e)
 				return false
 			}
-			var service *corev1.Service
-			var ok bool
-			if service, ok = e.Object.(*corev1.Service); !ok {
+			if _, ok := e.Object.(*corev1.Service); !ok {
 				return false
 			}
-			ips := getServiceLoadBalancerIPs(service)
-			if len(ips) > 0 {
-				logger.Info("Deleting a service with LoadBalancer IPs")
-				return true
-			}
-			return false
+			logger.Info("Deleting a service")
+			return true
 		},
 
 		GenericFunc: func(e event.GenericEvent) bool {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -32,9 +32,11 @@ import (
 // Actuator acts upon objects being reconciled by a Reconciler.
 type Actuator interface {
 	// CreateOrUpdate reconciles object creation or update.
-	CreateOrUpdate(context.Context, runtime.Object) (time.Duration, bool, error)
+	CreateOrUpdate(context.Context, runtime.Object) (time.Duration, error)
 	// Delete reconciles object deletion.
 	Delete(context.Context, runtime.Object) error
+	// ShouldFinalize returns true if the object should be finalized.
+	ShouldFinalize(context.Context, runtime.Object) (bool, error)
 }
 
 // AddArgs are arguments for adding a controller to a manager.

--- a/pkg/mock/remedy-controller/controller/mocks.go
+++ b/pkg/mock/remedy-controller/controller/mocks.go
@@ -36,13 +36,12 @@ func (m *MockActuator) EXPECT() *MockActuatorMockRecorder {
 }
 
 // CreateOrUpdate mocks base method
-func (m *MockActuator) CreateOrUpdate(arg0 context.Context, arg1 runtime.Object) (time.Duration, bool, error) {
+func (m *MockActuator) CreateOrUpdate(arg0 context.Context, arg1 runtime.Object) (time.Duration, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateOrUpdate", arg0, arg1)
 	ret0, _ := ret[0].(time.Duration)
-	ret1, _ := ret[1].(bool)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // CreateOrUpdate indicates an expected call of CreateOrUpdate
@@ -63,4 +62,19 @@ func (m *MockActuator) Delete(arg0 context.Context, arg1 runtime.Object) error {
 func (mr *MockActuatorMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockActuator)(nil).Delete), arg0, arg1)
+}
+
+// ShouldFinalize mocks base method
+func (m *MockActuator) ShouldFinalize(arg0 context.Context, arg1 runtime.Object) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShouldFinalize", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ShouldFinalize indicates an expected call of ShouldFinalize
+func (mr *MockActuatorMockRecorder) ShouldFinalize(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldFinalize", reflect.TypeOf((*MockActuator)(nil).ShouldFinalize), arg0, arg1)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
* Changes the service predicate to not filter any `Create` events. 
* Changes the `Actuator` interface and the `Reconciler` behavior as described in #24.

**Which issue(s) this PR fixes**:
Fixes #24

**Special notes for your reviewer**:

**Release note**:
```improvement operator
NONE
```
