### PR TITLE
Add service to expose metrics ports to the Helm chart

### DIFF
--- a/charts/remedy-controller-azure/templates/service.yaml
+++ b/charts/remedy-controller-azure/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: remedy-controller-azure
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: remedy-controller-azure
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: {{ .Values.manager.metricsPort }}
+    protocol: TCP
+  - name: target-metrics
+    port: {{ .Values.targetManager.metricsPort }}
+    protocol: TCP
+  selector:
+    app: remedy-controller-azure


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a service to expose metrics ports to the Helm chart.

**Special notes for your reviewer**:
* The service is the same as in https://github.com/gardener/gardener-extension-provider-azure/pull/127. The Prometheus configmap and Grafana dashboard are intentionally not part of this PR since using the Helm chart doesn't assume any existing monitoring stack. The service however is essential to being able to scrape metrics with any stack.
* Based on #27.

**Release note**:
```improvement operator
NONE
```
