### PR TITLE
Move Integration Test to Test Machinery

### DIFF
--- a/.ci/flavours/min-shoot-flavor-az.yaml
+++ b/.ci/flavours/min-shoot-flavor-az.yaml
@@ -1,0 +1,46 @@
+flavors:
+- provider: azure
+  kubernetes:
+    pattern: "latest"
+  cloudprofile: az
+  projectName: it
+  secretBinding: shoot-operator-az
+  region: westeurope
+  infrastructureConfig:
+    apiVersion: azure.provider.extensions.gardener.cloud/v1alpha1
+    kind: InfrastructureConfig
+    networks:
+      vnet:
+        cidr: 10.250.0.0/16
+      workers: 10.250.0.0/19
+    zoned: true
+  workers:
+  - workerPools:
+    - name: fail-me
+      machine:
+        type: Standard_D2_v3
+        image:
+          name: gardenlinux
+          version: latest
+      minimum: 2
+      maximum: 2
+      volume:
+        size: 35Gi
+        type: Standard_LRS
+      zones:
+      - "1"
+      - "2"
+    - name: test-nodes
+      machine:
+        type: Standard_D2_v3
+        image:
+          name: gardenlinux
+          version: latest
+      minimum: 1
+      maximum: 1
+      volume:
+        size: 35Gi
+        type: Standard_LRS
+      zones:
+      - "1"
+

--- a/.ci/integration_test.sh
+++ b/.ci/integration_test.sh
@@ -7,7 +7,10 @@ repo_dir="$(readlink -f "$(dirname "${0}")/..")"
 # HACK: will fail at installation of python, which is already provided - we only need helm in this image
 make -C "${repo_dir}" install-requirements || true
 
+# need to setup the CRDs in the test-cluster
+kubectl --kubeconfig "${TM_KUBECONFIG_PATH}/shoot.config" apply -f "${repo_dir}/example/20-crd-publicipaddress.yaml"
+kubectl --kubeconfig "${TM_KUBECONFIG_PATH}/shoot.config" apply -f "${repo_dir}/example/20-crd-virtualmachine.yaml"
+
 pip3 install -r "${repo_dir}/test/requirements.txt"
 
-python3 "${repo_dir}/.ci/integration_test.py" \
-    --kubeconfig-name remedy-test-cluster --credentials-config-name integration_test
+python3 "${repo_dir}/.ci/integration_test.py"

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -46,12 +46,19 @@ remedy-controller:
       repo:
         trigger: false
       steps:
-        test:
-          image: 'eu.gcr.io/gardener-project/cc/job-image-golang:0.12.0'
-          execute:
-            - integration_test.sh
-          depends:
-            - publish
+        remedy-controller:
+          steps:
+            testrun:
+              image: eu.gcr.io/gardener-project/gardener/testmachinery/testmachinery-run:stable
+              execute:
+              - tm-test
+              - --flavor-tm-chart=default
+              - --flavor-config=min-shoot-flavor-az.yaml
+              - --landscape=opensource
+              - --tm-landscape=external
+              - --
+              - --testrun-prefix=remedy-controller
+              - --set=projectNamespace=garden-it
         trigger_release:
           execute:
             - trigger_release.py

--- a/.ci/testruns/default/.helmignore
+++ b/.ci/testruns/default/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/.ci/testruns/default/Chart.yaml
+++ b/.ci/testruns/default/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: testruns
+version: 0.1.0

--- a/.ci/testruns/default/templates/_generators.tpl
+++ b/.ci/testruns/default/templates/_generators.tpl
@@ -1,0 +1,101 @@
+{{- define "generator" }}
+{{ if eq .Values.shoot.cloudprovider "gcp" }}
+  - name: generate-provider
+    annotations:
+      testmachinery.sapcloud.io/system-step: "true"
+    definition:
+      name: gen-provider-gcp
+      config:
+      - name: CONTROLPLANE_PROVIDER_CONFIG_FILEPATH
+        type: env
+        value: /tmp/tm/shared/generators/controlplane.yaml
+      - name: INFRASTRUCTURE_PROVIDER_CONFIG_FILEPATH
+        type: env
+        value: /tmp/tm/shared/generators/infra.yaml
+      - name: ZONE
+        type: env
+        value: {{ required "a zone is required for gcp shoots" .Values.shoot.zone }}
+{{ else if eq .Values.shoot.cloudprovider "aws" }}
+  - name: generate-provider
+    annotations:
+      testmachinery.sapcloud.io/system-step: "true"
+    definition:
+      name: gen-provider-aws
+      config:
+      - name: CONTROLPLANE_PROVIDER_CONFIG_FILEPATH
+        type: env
+        value: /tmp/tm/shared/generators/controlplane.yaml
+      - name: INFRASTRUCTURE_PROVIDER_CONFIG_FILEPATH
+        type: env
+        value: /tmp/tm/shared/generators/infra.yaml
+      - name: ZONE
+        type: env
+        value: {{ required "a zone is required for aws shoots" .Values.shoot.zone }}
+{{ else if eq .Values.shoot.cloudprovider "azure" }}
+  - name: generate-provider
+    annotations:
+      testmachinery.sapcloud.io/system-step: "true"
+    definition:
+      name: gen-provider-azure
+      config:
+      - name: CONTROLPLANE_PROVIDER_CONFIG_FILEPATH
+        type: env
+        value: /tmp/tm/shared/generators/controlplane.yaml
+      - name: INFRASTRUCTURE_PROVIDER_CONFIG_FILEPATH
+        type: env
+        value: /tmp/tm/shared/generators/infra.yaml
+{{ else if eq .Values.shoot.cloudprovider "alicloud" }}
+  - name: generate-provider
+    annotations:
+      testmachinery.sapcloud.io/system-step: "true"
+    definition:
+      name: gen-provider-alicloud
+      config:
+      - name: CONTROLPLANE_PROVIDER_CONFIG_FILEPATH
+        type: env
+        value: /tmp/tm/shared/generators/controlplane.yaml
+      - name: INFRASTRUCTURE_PROVIDER_CONFIG_FILEPATH
+        type: env
+        value: /tmp/tm/shared/generators/infra.yaml
+      - name: ZONE
+        type: env
+        value: {{ required "a zone is required for alicloud shoots" .Values.shoot.zone }}
+{{ else if eq .Values.shoot.cloudprovider "openstack" }}
+  - name: generate-provider
+    annotations:
+      testmachinery.sapcloud.io/system-step: "true"
+    definition:
+      name: gen-provider-openstack
+      config:
+      - name: CONTROLPLANE_PROVIDER_CONFIG_FILEPATH
+        type: env
+        value: /tmp/tm/shared/generators/controlplane.yaml
+      - name: INFRASTRUCTURE_PROVIDER_CONFIG_FILEPATH
+        type: env
+        value: /tmp/tm/shared/generators/infra.yaml
+      - name: ZONE
+        type: env
+        value: {{ required "a zone is required for openstack shoots" .Values.shoot.zone }}
+      - name: FLOATING_POOL_NAME
+        type: env
+        value: {{ required "floating pool name is required for openstack shoots" .Values.shoot.floatingPoolName }}
+      - name: LOADBALANCER_PROVIDER
+        type: env
+        value: {{ required "a loadbalancer provider name is required for openstack shoots" .Values.shoot.loadbalancerProvider }}
+{{ end }}
+{{- end }}
+
+{{- define "config-overwrites" }}
+      {{ if .Values.shoot.infrastructureConfig }}
+      - name: INFRASTRUCTURE_PROVIDER_CONFIG_FILEPATH
+        type: file
+        path: /tmp/tm/shared/generators/infra.yaml
+        value: {{ .Values.shoot.infrastructureConfig }}
+      {{ end }}
+      {{ if .Values.shoot.controlplaneConfig }}
+      - name: CONTROLPLANE_PROVIDER_CONFIG_FILEPATH
+        type: file
+        path: /tmp/tm/shared/generators/controlplane.yaml
+        value: {{ .Values.shoot.controlplaneConfig }}
+      {{ end }}
+{{- end }}

--- a/.ci/testruns/default/templates/testrun.yaml
+++ b/.ci/testruns/default/templates/testrun.yaml
@@ -1,0 +1,145 @@
+# TestRun CRDs will be created by Test-Machinery controllers, by concourse jobs or manually to run e.g. single tests.
+apiVersion: testmachinery.sapcloud.io/v1beta1
+kind: Testrun
+metadata:
+  name: {{ .Values.testrunName }}
+  namespace: default
+spec:
+
+  ttlSecondsAfterFinished: 172800 # 2 days
+
+  # defines where to look for TestDefs
+  locationSets:
+  - name: default
+    default: true
+    locations:
+    - type: git
+      repo: https://github.com/gardener/gardener.git
+      revision: master
+    - type: git
+      repo: https://github.com/gardener/gardener-extension-provider-aws.git
+      revision: master
+    - type: git
+      repo: https://github.com/gardener/gardener-extension-provider-gcp.git
+      revision: master
+    - type: git
+      repo: https://github.com/gardener/gardener-extension-provider-azure.git
+      revision: master
+    - type: git
+      repo: https://github.com/gardener/gardener-extension-provider-alicloud.git
+      revision: master
+    - type: git
+      repo: https://github.com/gardener/gardener-extension-provider-openstack.git
+      revision: master
+    - type: git
+      repo: https://github.com/gardener/remedy-controller.git
+      revision: {{ .Values.revision }}
+
+  kubeconfigs:
+    gardener: {{ b64enc .Values.kubeconfigs.gardener }}
+
+
+  # Global config available to every test task in all phases (testFlow and onExit)
+  config:
+  - name: PROJECT_NAMESPACE
+    type: env
+    value: {{ .Values.shoot.projectNamespace }}
+  - name: SHOOT_NAME
+    type: env
+    value: {{ .Values.shoot.name }}
+  - name: CLOUDPROVIDER
+    type: env
+    value: {{ .Values.shoot.cloudprovider }}
+  - name: K8S_VERSION
+    type: env
+    value: {{ .Values.shoot.k8sVersion }}
+  - name: ACCESS_KEY_ID
+    type: env
+    valueFrom:
+      secretKeyRef:
+        name: shoot-operator-aws
+        key: accessKeyID
+  - name: SECRET_ACCESS_KEY
+    type: env
+    valueFrom:
+      secretKeyRef:
+        name: shoot-operator-aws
+        key: secretAccessKey
+  - name: AWS_REGION
+    type: env
+    value: eu-west-1
+
+  - name: SUBSCRIPTION_ID
+    type: env
+    valueFrom:
+      secretKeyRef:
+        name: shoot-operator-az
+        key: subscriptionID
+  - name: TENANT_ID
+    type: env
+    valueFrom:
+      secretKeyRef:
+        name: shoot-operator-az
+        key: tenantID
+  - name: CLIENT_ID
+    type: env
+    valueFrom:
+      secretKeyRef:
+        name: shoot-operator-az
+        key: clientID
+  - name: CLIENT_SECRET
+    type: env
+    valueFrom:
+      secretKeyRef:
+        name: shoot-operator-az
+        key: clientSecret
+  - name: REGION
+    type: env
+    value: {{ .Values.shoot.region }}
+
+  # the execution flow:
+  testflow:
+  {{ include "generator" . }}
+
+  - name: create
+    dependsOn: [ generate-provider ]
+    definition:
+      name: create-shoot
+      config:
+      - name: PROVIDER_TYPE
+        type: env
+        value: {{ .Values.shoot.cloudprovider }}
+      - name: CLOUDPROFILE
+        type: env
+        value: {{ .Values.shoot.cloudprofile }}
+      - name: SECRET_BINDING
+        type: env
+        value: {{ .Values.shoot.secretBinding }}
+      - name: NETWORKING_PODS
+        type: env
+        value: 100.64.0.0/11
+      - name: NETWORKING_SERVICES
+        type: env
+        value: 100.104.0.0/13
+      {{ if .Values.shoot.workers }}
+      - name: WORKERS_CONFIG_FILEPATH
+        type: file
+        path: /tmp/tm/shared/generators/workers.yaml
+        value: {{ .Values.shoot.workers }}
+      {{ end }}
+      {{ include "config-overwrites" . }}
+
+  - name: tests
+    dependsOn: [ create ]
+    definition:
+      name: integration-test
+  - name: delete
+    dependsOn: [ tests ]
+    definition:
+      name: delete-shoot
+
+  onExit:
+  - name: delete
+    definition:
+      name: delete-shoot
+      condition: error

--- a/.ci/testruns/default/values.yaml
+++ b/.ci/testruns/default/values.yaml
@@ -1,0 +1,26 @@
+# Default values for testruns.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+
+testrunName: ""
+shoot:
+  name: ""
+  domain: ""
+  projectNamespace: ""
+  cloudprovider: ""
+  cloudprofile: ""
+  secretBinding: ""
+  region: ""
+  zone: ""
+  k8sVersion: ""
+  machinetype: ""
+  autoscalerMin: ""
+  autoscalerMax: ""
+  floatingPoolName: ""
+  loadbalancerProvider: ""
+
+kubeconfigs:
+  gardener: ""
+  seed: ""
+  shoot: ""

--- a/.ci/tm-test
+++ b/.ci/tm-test
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -e
+
+FLAVOR_TESTRUN_CHART=""
+FLAVOR_CONFIG="min-shoot-flavor.yaml"
+TM_LANDSCAPE="external"
+LANDSCAPE=""
+ARGUMENTS=""
+
+
+for i in "$@"
+do
+echo $i
+case $i in
+        -flavor-tm-chart=*|--flavor-tm-chart=*)
+        FLAVOR_TESTRUN_CHART="${i#*=}"
+        shift
+    ;;
+        -flavor-config=*|--flavor-config=*)
+        FLAVOR_CONFIG="${i#*=}"
+        shift
+    ;;
+        -tm-landscape=*|--tm-landscape=*)
+        TM_LANDSCAPE="${i#*=}"
+        shift
+    ;;
+        -landscape=*|--landscape=*)
+        LANDSCAPE="${i#*=}"
+        shift
+    ;;
+        --)
+        ARGUMENTS="${@:2}"
+        break
+    ;;
+    *)
+        # unknown option
+        echo "Unkown option ${i#*=}"
+        exit 1
+    ;;
+esac
+done
+
+if [[ $TM_LANDSCAPE == "" ]]; then
+    echo "Required parameter: -tm-landscape : external | internal"
+    exit 1
+fi
+if [[ $LANDSCAPE == "" ]]; then
+    echo "Required parameter: -landscape"
+    exit 1
+fi
+
+if [[ $TM_LANDSCAPE == "external" ]]; then
+    TM_CONFIG_NAME=testmachinery
+    S3_ENDPOINT="storage.googleapis.com"
+fi
+
+echo "Testmachinery config name: ${TM_CONFIG_NAME}"
+echo "Testmachinery landscape: ${TM_LANDSCAPE}"
+echo "Arguments: ${ARGUMENTS}"
+
+
+export SOURCE_PATH="$(readlink -f "$(dirname ${0})/..")"
+mkdir -p /tm
+TM_CLUSTER=/tm/kubeconfig
+ACTIVE_GARDEN_CLUSTER=/tm/gardener.kubeconfig
+cli.py config attribute --cfg-type kubernetes --cfg-name garden-dev-virtual --key kubeconfig > $ACTIVE_GARDEN_CLUSTER
+
+if [[ $FLAVOR_TESTRUN_CHART != "" ]]; then
+    FLAVOR_TESTRUN_CHART_PATH="$SOURCE_PATH/.ci/testruns/$FLAVOR_TESTRUN_CHART"
+fi
+
+mkdir -p /tm
+cli.py config attribute --cfg-type kubernetes --cfg-name $TM_CONFIG_NAME --key kubeconfig > $TM_CLUSTER
+
+export KUBECONFIG=$TM_CLUSTER
+
+# timeout to 6h
+/testrunner run \
+    --gardener-kubeconfig-path=$ACTIVE_GARDEN_CLUSTER \
+    --tm-kubeconfig-path=$TM_CLUSTER \
+    --timeout=21600 \
+    --interval=60 \
+    --es-config-name=sap_internal \
+    --landscape=$LANDSCAPE \
+    --s3-endpoint=$S3_ENDPOINT \
+    --s3-ssl=true \
+    --shoot-name="tm-" \
+    --flavored-testruns-chart-path=$FLAVOR_TESTRUN_CHART_PATH \
+    --flavor-config=$SOURCE_PATH/.ci/flavors/$FLAVOR_CONFIG \
+    $ARGUMENTS

--- a/.test-defs/integration-test.yaml
+++ b/.test-defs/integration-test.yaml
@@ -1,0 +1,50 @@
+kind: TestDefinition
+metadata:
+  name: integration-test
+spec:
+  owner: andreas.burger@sap.com # test owner and contact person in case of a test failure
+  recipientsOnFailure:
+  - s.rachev@sap.com
+  - georgi.chulkov@sap.com # optional, list of emails to be notified if a step fails
+  description: "Integration test" # optional; description of the test.
+
+  activeDeadlineSeconds: 2700 # optional; maximum seconds to wait for the test to finish.
+
+  # optional, specify specific behavior of a test.
+  # By default steps are executed in parallel.
+  # By specifying "serial behavior", tests can be forced to be executed in serial.
+  behavior: ["serial"]
+
+  # required; Entrypoint array. Not executed within a shell.
+  # The docker image's ENTRYPOINT is used if this is not provided.
+  command: [bash, -c]
+  # Arguments to the entrypoint. The docker image's CMD is used if this is not provided.
+  args: [".ci/integration_test.sh"]
+
+  # image: eu.gcr.io/gardener-project/cc/job-image-golang:0.12.0
+
+  # optional; Configuration of a TestDefinition.
+  # Environment Variables can be configured per TestDefinition
+  # by specifying the varibale's name and a value, secret or configmap.
+  # Files can be mounted into the test by specifying a base64 encoded value, secret or configmap.
+  # config:
+  # - type: env
+  #   name: TESTENV1
+  #   value: "Env content"
+  # - type: env
+  #   name: TESTENV2
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: secretName
+  #       key: secretKey
+  # - type: file
+  #   name: file1 # name for description
+  #   path: /tmp/tm/file1.txt
+  #   value: "aGVsbG8gd29ybGQK" # base64 encoded file content: "hello world"
+  # - type: file
+  #   name: file2
+  #   path: /tmp/tm/file2.txt
+  #   valueFrom:
+  #     configMapKeyRef:
+  #       name: configmapName
+  #       key: configmapKey


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the central integration-test job so that it runs in a Test-Machinery-created shoot instead of a preprovisioned one.

**Special notes for your reviewer**:
Not sure whether there is something else to do on the TM side of things. Let's not merge it until @schrodit gives the all-clear.

