### PR TITLE
Fix getting the Azure public IP address in the publicipaddress actuator

### DIFF
--- a/pkg/controller/azure/constants.go
+++ b/pkg/controller/azure/constants.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+const (
+	// IgnoreAnnotation is an annotation that can be used to specify that a particular service should be ignored.
+	IgnoreAnnotation = "azure.remedy.gardener.cloud/ignore"
+	// DoNotCleanAnnotation is an annotation that can be used to specify that a particular PublicIPAddress
+	// should be not be cleaned when deleted.
+	DoNotCleanAnnotation = "azure.remedy.gardener.cloud/do-not-clean"
+
+	// ServiceLabel is the label to put on a PublicIPAddress object that identifies its service.
+	ServiceLabel = "azure.remedy.gardener.cloud/service"
+	// NodeLabel is the label to put on a VirtualMachine object that identifies its node.
+	NodeLabel = "azure.remedy.gardener.cloud/node"
+)

--- a/pkg/controller/azure/node/actuator.go
+++ b/pkg/controller/azure/node/actuator.go
@@ -20,6 +20,7 @@ import (
 
 	azurev1alpha1 "github.com/gardener/remedy-controller/pkg/apis/azure/v1alpha1"
 	"github.com/gardener/remedy-controller/pkg/controller"
+	"github.com/gardener/remedy-controller/pkg/controller/azure"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -32,8 +33,6 @@ import (
 )
 
 const (
-	// Label is the label to put on a VirtualMachine object that identifies its node.
-	Label = "azure.remedy.gardener.cloud/node"
 	// TaintKeyUnreachable is the taint key to determine whether a node is unreachable.
 	TaintKeyUnreachable = "node.kubernetes.io/unreachable"
 	// HostnameLabel is a label to determine the hostname of a node.
@@ -67,7 +66,7 @@ func (a *actuator) CreateOrUpdate(ctx context.Context, obj runtime.Object) (requ
 
 	// Initialize labels
 	vmLabels := map[string]string{
-		Label: node.Name,
+		azure.NodeLabel: node.Name,
 	}
 
 	// Get node properties

--- a/pkg/controller/azure/node/actuator_test.go
+++ b/pkg/controller/azure/node/actuator_test.go
@@ -21,6 +21,7 @@ import (
 
 	azurev1alpha1 "github.com/gardener/remedy-controller/pkg/apis/azure/v1alpha1"
 	"github.com/gardener/remedy-controller/pkg/controller"
+	"github.com/gardener/remedy-controller/pkg/controller/azure"
 	azurenode "github.com/gardener/remedy-controller/pkg/controller/azure/node"
 	mockclient "github.com/gardener/remedy-controller/pkg/mock/controller-runtime/client"
 
@@ -88,7 +89,7 @@ var _ = Describe("Actuator", func() {
 			},
 		}
 		vmLabels = map[string]string{
-			azurenode.Label: nodeName,
+			azure.NodeLabel: nodeName,
 		}
 		emptyVM = &azurev1alpha1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/azure/service/actuator_test.go
+++ b/pkg/controller/azure/service/actuator_test.go
@@ -22,7 +22,7 @@ import (
 
 	azurev1alpha1 "github.com/gardener/remedy-controller/pkg/apis/azure/v1alpha1"
 	"github.com/gardener/remedy-controller/pkg/controller"
-	azurepublicipaddress "github.com/gardener/remedy-controller/pkg/controller/azure/publicipaddress"
+	"github.com/gardener/remedy-controller/pkg/controller/azure"
 	azureservice "github.com/gardener/remedy-controller/pkg/controller/azure/service"
 	mockclient "github.com/gardener/remedy-controller/pkg/mock/controller-runtime/client"
 
@@ -103,7 +103,7 @@ var _ = Describe("Actuator", func() {
 				Name:      serviceName,
 				Namespace: serviceNamespace,
 				Annotations: map[string]string{
-					azureservice.IgnoreAnnotation: strconv.FormatBool(true),
+					azure.IgnoreAnnotation: strconv.FormatBool(true),
 				},
 			},
 			Spec: corev1.ServiceSpec{
@@ -118,7 +118,7 @@ var _ = Describe("Actuator", func() {
 			},
 		}
 		pubipLabels = map[string]string{
-			azureservice.Label: serviceNamespace + "." + serviceName,
+			azure.ServiceLabel: serviceNamespace + "." + serviceName,
 		}
 		emptyPubip = &azurev1alpha1.PublicIPAddress{
 			ObjectMeta: metav1.ObjectMeta{
@@ -142,7 +142,7 @@ var _ = Describe("Actuator", func() {
 				Namespace: namespace,
 				Labels:    pubipLabels,
 				Annotations: map[string]string{
-					azurepublicipaddress.DoNotCleanAnnotation: strconv.FormatBool(true),
+					azure.DoNotCleanAnnotation: strconv.FormatBool(true),
 				},
 			},
 			Spec: azurev1alpha1.PublicIPAddressSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes getting the Azure public IP address in the `publicipaddress` actuator to avoid the issues described in #35.

**Which issue(s) this PR fixes**:
Fixes #35

**Special notes for your reviewer**:

**Release note**:
```improvement operator
Fixed a bug that caused the public IP address created by the CCM to be deleted by the remedy controller in some circumstances.
```
