### PR TITLE
depend on publish-trait rather than injected step(s)

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -91,7 +91,7 @@ remedy-controller:
           - --
           - --testrun-prefix=remedy-controller
           - --set=projectNamespace=garden-it
-          depends:
+          trait_depends:
             - publish
       traits:
         version:

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ install-requirements:
 
 	@$(REPO_ROOT)/hack/install-requirements.sh
 	@python3 -m venv $(REPO_ROOT)/.env
-	@. $(REPO_ROOT)/.env/bin/activate && pip3 install -r $(REPO_ROOT)/test/requirements.txt
+	@. $(REPO_ROOT)/.env/bin/activate && pip3 install --upgrade pip && pip3 install -r $(REPO_ROOT)/test/requirements.txt
 
 
 .PHONY: revendor


### PR DESCRIPTION
**What this PR does / why we need it**:
prepare switching to kaniko as default-builder