### PR TITLE
 Add `SyncPeriod` for remedies

### DIFF
--- a/charts/remedy-controller-azure/templates/configmap.yaml
+++ b/charts/remedy-controller-azure/templates/configmap.yaml
@@ -17,11 +17,13 @@ data:
     azure:
       orphanedPublicIPRemedy:
         requeueInterval: {{ required ".Values.config.azure.orphanedPublicIPRemedy.requeueInterval is required" .Values.config.azure.orphanedPublicIPRemedy.requeueInterval }}
+        syncPeriod: {{ required ".Values.config.azure.orphanedPublicIPRemedy.syncPeriod is required" .Values.config.azure.orphanedPublicIPRemedy.syncPeriod }}
         deletionGracePeriod: {{ required ".Values.config.azure.orphanedPublicIPRemedy.deletionGracePeriod is required" .Values.config.azure.orphanedPublicIPRemedy.deletionGracePeriod }}
         maxGetAttempts: {{ required ".Values.config.azure.orphanedPublicIPRemedy.maxGetAttempts is required" .Values.config.azure.orphanedPublicIPRemedy.maxGetAttempts }}
         maxCleanAttempts: {{ required ".Values.config.azure.orphanedPublicIPRemedy.maxReapplyAttempts is required" .Values.config.azure.orphanedPublicIPRemedy.maxCleanAttempts }}
       failedVMRemedy:
         requeueInterval: {{ required ".Values.config.azure.failedVMRemedy.requeueInterval is required" .Values.config.azure.failedVMRemedy.requeueInterval }}
+        syncPeriod: {{ required ".Values.config.azure.failedVMRemedy.syncPeriod is required" .Values.config.azure.failedVMRemedy.syncPeriod }}
         maxGetAttempts: {{ required ".Values.config.azure.failedVMRemedy.maxGetAttempts is required" .Values.config.azure.failedVMRemedy.maxGetAttempts }}
         maxReapplyAttempts: {{ required ".Values.config.azure.failedVMRemedy.maxReapplyAttempts is required" .Values.config.azure.failedVMRemedy.maxReapplyAttempts }}
 {{- end }}

--- a/charts/remedy-controller-azure/values.yaml
+++ b/charts/remedy-controller-azure/values.yaml
@@ -38,11 +38,13 @@ config:
   azure:
     orphanedPublicIPRemedy:
       requeueInterval: 1m
+      syncPeriod: 10h
       deletionGracePeriod: 5m
       maxGetAttempts: 5
       maxCleanAttempts: 5
     failedVMRemedy:
       requeueInterval: 1m
+      syncPeriod: 2h
       maxGetAttempts: 5
       maxReapplyAttempts: 5
 

--- a/example/00-config.yaml
+++ b/example/00-config.yaml
@@ -9,10 +9,12 @@ clientConnection:
 azure:
   orphanedPublicIPRemedy:
     requeueInterval: 1m
+    syncPeriod: 10h
     deletionGracePeriod: 5m
     maxGetAttempts: 5
     maxCleanAttempts: 5
   failedVMRemedy:
     requeueInterval: 30s
+    syncPeriod: 2h
     maxGetAttempts: 5
     maxReapplyAttempts: 3

--- a/hack/api-reference/config.md
+++ b/hack/api-reference/config.md
@@ -147,7 +147,22 @@ Kubernetes meta/v1.Duration
 <td>
 <em>(Optional)</em>
 <p>RequeueInterval specifies the time after which reconciliation requests will be
-requeued. Applies to both creation/update and deletion.</p>
+requeued in case of an error or a transient state. Applies to both creation/update and deletion.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>syncPeriod</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#duration-v1-meta">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SyncPeriod determines the minimum frequency at which VirtualMachine resources will be reconciled.
+Only applies to creation/update.</p>
 </td>
 </tr>
 <tr>
@@ -205,7 +220,22 @@ Kubernetes meta/v1.Duration
 <td>
 <em>(Optional)</em>
 <p>RequeueInterval specifies the time after which reconciliation requests will be
-requeued. Applies to both creation/update and deletion.</p>
+requeued in case of an error or a transient state. Applies to both creation/update and deletion.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>syncPeriod</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#duration-v1-meta">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SyncPeriod determines the minimum frequency at which PublicIPAddress resources will be reconciled.
+Only applies to creation/update.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/config/types.go
+++ b/pkg/apis/config/types.go
@@ -42,8 +42,11 @@ type AzureConfiguration struct {
 // AzureOrphanedPublicIPRemedyConfiguration defines the configuration for the Azure orphaned public IP remedy.
 type AzureOrphanedPublicIPRemedyConfiguration struct {
 	// RequeueInterval specifies the time after which reconciliation requests will be
-	// requeued. Applies to both creation/update and deletion.
+	// requeued in case of an error or a transient state. Applies to both creation/update and deletion.
 	RequeueInterval metav1.Duration
+	// SyncPeriod determines the minimum frequency at which PublicIPAddress resources will be reconciled.
+	// Only applies to creation/update.
+	SyncPeriod metav1.Duration
 	// DeletionGracePeriod specifies the period after which a public ip address will be
 	// deleted by the controller if it still exists.
 	DeletionGracePeriod metav1.Duration
@@ -56,8 +59,11 @@ type AzureOrphanedPublicIPRemedyConfiguration struct {
 // AzureFailedVMRemedyConfiguration defines the configuration for the Azure failed VM remedy.
 type AzureFailedVMRemedyConfiguration struct {
 	// RequeueInterval specifies the time after which reconciliation requests will be
-	// requeued. Applies to both creation/update and deletion.
+	// requeued in case of an error or a transient state. Applies to both creation/update and deletion.
 	RequeueInterval metav1.Duration
+	// SyncPeriod determines the minimum frequency at which VirtualMachine resources will be reconciled.
+	// Only applies to creation/update.
+	SyncPeriod metav1.Duration
 	// MaxGetAttempts specifies the max attempts to get an Azure VM.
 	MaxGetAttempts int
 	// MaxReapplyAttempts specifies the max attempts to reapply an Azure VM.

--- a/pkg/apis/config/v1alpha1/types.go
+++ b/pkg/apis/config/v1alpha1/types.go
@@ -47,9 +47,13 @@ type AzureConfiguration struct {
 // AzureOrphanedPublicIPRemedyConfiguration defines the configuration for the Azure orphaned public IP remedy.
 type AzureOrphanedPublicIPRemedyConfiguration struct {
 	// RequeueInterval specifies the time after which reconciliation requests will be
-	// requeued. Applies to both creation/update and deletion.
+	// requeued in case of an error or a transient state. Applies to both creation/update and deletion.
 	// +optional
 	RequeueInterval metav1.Duration `json:"requeueInterval,omitempty"`
+	// SyncPeriod determines the minimum frequency at which PublicIPAddress resources will be reconciled.
+	// Only applies to creation/update.
+	// +optional
+	SyncPeriod metav1.Duration `json:"syncPeriod,omitempty"`
 	// DeletionGracePeriod specifies the period after which a public ip address will be
 	// deleted by the controller if it still exists.
 	// +optional
@@ -65,9 +69,13 @@ type AzureOrphanedPublicIPRemedyConfiguration struct {
 // AzureFailedVMRemedyConfiguration defines the configuration for the Azure failed VM remedy.
 type AzureFailedVMRemedyConfiguration struct {
 	// RequeueInterval specifies the time after which reconciliation requests will be
-	// requeued. Applies to both creation/update and deletion.
+	// requeued in case of an error or a transient state. Applies to both creation/update and deletion.
 	// +optional
 	RequeueInterval metav1.Duration `json:"requeueInterval,omitempty"`
+	// SyncPeriod determines the minimum frequency at which VirtualMachine resources will be reconciled.
+	// Only applies to creation/update.
+	// +optional
+	SyncPeriod metav1.Duration `json:"syncPeriod,omitempty"`
 	// MaxGetAttempts specifies the max attempts to get an Azure VM.
 	// +optional
 	MaxGetAttempts int `json:"maxGetAttempts,omitempty"`

--- a/pkg/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.conversion.go
@@ -104,6 +104,7 @@ func Convert_config_AzureConfiguration_To_v1alpha1_AzureConfiguration(in *config
 
 func autoConvert_v1alpha1_AzureFailedVMRemedyConfiguration_To_config_AzureFailedVMRemedyConfiguration(in *AzureFailedVMRemedyConfiguration, out *config.AzureFailedVMRemedyConfiguration, s conversion.Scope) error {
 	out.RequeueInterval = in.RequeueInterval
+	out.SyncPeriod = in.SyncPeriod
 	out.MaxGetAttempts = in.MaxGetAttempts
 	out.MaxReapplyAttempts = in.MaxReapplyAttempts
 	return nil
@@ -116,6 +117,7 @@ func Convert_v1alpha1_AzureFailedVMRemedyConfiguration_To_config_AzureFailedVMRe
 
 func autoConvert_config_AzureFailedVMRemedyConfiguration_To_v1alpha1_AzureFailedVMRemedyConfiguration(in *config.AzureFailedVMRemedyConfiguration, out *AzureFailedVMRemedyConfiguration, s conversion.Scope) error {
 	out.RequeueInterval = in.RequeueInterval
+	out.SyncPeriod = in.SyncPeriod
 	out.MaxGetAttempts = in.MaxGetAttempts
 	out.MaxReapplyAttempts = in.MaxReapplyAttempts
 	return nil
@@ -128,6 +130,7 @@ func Convert_config_AzureFailedVMRemedyConfiguration_To_v1alpha1_AzureFailedVMRe
 
 func autoConvert_v1alpha1_AzureOrphanedPublicIPRemedyConfiguration_To_config_AzureOrphanedPublicIPRemedyConfiguration(in *AzureOrphanedPublicIPRemedyConfiguration, out *config.AzureOrphanedPublicIPRemedyConfiguration, s conversion.Scope) error {
 	out.RequeueInterval = in.RequeueInterval
+	out.SyncPeriod = in.SyncPeriod
 	out.DeletionGracePeriod = in.DeletionGracePeriod
 	out.MaxGetAttempts = in.MaxGetAttempts
 	out.MaxCleanAttempts = in.MaxCleanAttempts
@@ -141,6 +144,7 @@ func Convert_v1alpha1_AzureOrphanedPublicIPRemedyConfiguration_To_config_AzureOr
 
 func autoConvert_config_AzureOrphanedPublicIPRemedyConfiguration_To_v1alpha1_AzureOrphanedPublicIPRemedyConfiguration(in *config.AzureOrphanedPublicIPRemedyConfiguration, out *AzureOrphanedPublicIPRemedyConfiguration, s conversion.Scope) error {
 	out.RequeueInterval = in.RequeueInterval
+	out.SyncPeriod = in.SyncPeriod
 	out.DeletionGracePeriod = in.DeletionGracePeriod
 	out.MaxGetAttempts = in.MaxGetAttempts
 	out.MaxCleanAttempts = in.MaxCleanAttempts

--- a/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -55,6 +55,7 @@ func (in *AzureConfiguration) DeepCopy() *AzureConfiguration {
 func (in *AzureFailedVMRemedyConfiguration) DeepCopyInto(out *AzureFailedVMRemedyConfiguration) {
 	*out = *in
 	out.RequeueInterval = in.RequeueInterval
+	out.SyncPeriod = in.SyncPeriod
 	return
 }
 
@@ -72,6 +73,7 @@ func (in *AzureFailedVMRemedyConfiguration) DeepCopy() *AzureFailedVMRemedyConfi
 func (in *AzureOrphanedPublicIPRemedyConfiguration) DeepCopyInto(out *AzureOrphanedPublicIPRemedyConfiguration) {
 	*out = *in
 	out.RequeueInterval = in.RequeueInterval
+	out.SyncPeriod = in.SyncPeriod
 	out.DeletionGracePeriod = in.DeletionGracePeriod
 	return
 }

--- a/pkg/apis/config/zz_generated.deepcopy.go
+++ b/pkg/apis/config/zz_generated.deepcopy.go
@@ -55,6 +55,7 @@ func (in *AzureConfiguration) DeepCopy() *AzureConfiguration {
 func (in *AzureFailedVMRemedyConfiguration) DeepCopyInto(out *AzureFailedVMRemedyConfiguration) {
 	*out = *in
 	out.RequeueInterval = in.RequeueInterval
+	out.SyncPeriod = in.SyncPeriod
 	return
 }
 
@@ -72,6 +73,7 @@ func (in *AzureFailedVMRemedyConfiguration) DeepCopy() *AzureFailedVMRemedyConfi
 func (in *AzureOrphanedPublicIPRemedyConfiguration) DeepCopyInto(out *AzureOrphanedPublicIPRemedyConfiguration) {
 	*out = *in
 	out.RequeueInterval = in.RequeueInterval
+	out.SyncPeriod = in.SyncPeriod
 	out.DeletionGracePeriod = in.DeletionGracePeriod
 	return
 }

--- a/pkg/controller/azure/publicipaddress/actuator.go
+++ b/pkg/controller/azure/publicipaddress/actuator.go
@@ -106,7 +106,7 @@ func (a *actuator) CreateOrUpdate(ctx context.Context, obj client.Object) (reque
 				RequeueAfter: a.config.RequeueInterval.Duration * (1 << (failedOperation.Attempts - 1)),
 			}
 		}
-		return 0, nil
+		return a.config.SyncPeriod.Duration, nil
 	}
 	azurev1alpha1.DeleteFailedOperation(&failedOperations, azurev1alpha1.OperationTypeGetPublicIPAddress)
 
@@ -116,7 +116,7 @@ func (a *actuator) CreateOrUpdate(ctx context.Context, obj client.Object) (reque
 	}
 
 	// Requeue if the Azure public IP address doesn't exist or is in a transient state
-	requeueAfter = 0
+	requeueAfter = a.config.SyncPeriod.Duration
 	if azurePublicIP == nil || (getProvisioningState(azurePublicIP) != network.Succeeded && getProvisioningState(azurePublicIP) != network.Failed) {
 		requeueAfter = a.config.RequeueInterval.Duration
 	}

--- a/pkg/controller/azure/publicipaddress/actuator_test.go
+++ b/pkg/controller/azure/publicipaddress/actuator_test.go
@@ -54,6 +54,7 @@ var _ = Describe("Actuator", func() {
 		azurePublicIPAddressName = "shoot--dev--test-ip1"
 
 		requeueInterval     = 1 * time.Second
+		syncPeriod          = 1 * time.Minute
 		deletionGracePeriod = 1 * time.Second
 	)
 
@@ -91,6 +92,7 @@ var _ = Describe("Actuator", func() {
 
 		cfg = config.AzureOrphanedPublicIPRemedyConfiguration{
 			RequeueInterval:     metav1.Duration{Duration: requeueInterval},
+			SyncPeriod:          metav1.Duration{Duration: syncPeriod},
 			DeletionGracePeriod: metav1.Duration{Duration: deletionGracePeriod},
 			MaxGetAttempts:      2,
 			MaxCleanAttempts:    2,
@@ -173,7 +175,7 @@ var _ = Describe("Actuator", func() {
 
 			requeueAfter, err := actuator.CreateOrUpdate(ctx, pubip.DeepCopyObject().(client.Object))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(requeueAfter).To(Equal(time.Duration(0)))
+			Expect(requeueAfter).To(Equal(syncPeriod))
 		})
 
 		It("should not update the PublicIPAddress object status if the IP is not found", func() {
@@ -205,7 +207,7 @@ var _ = Describe("Actuator", func() {
 
 			requeueAfter, err := actuator.CreateOrUpdate(ctx, pubipWithStatus.DeepCopyObject().(client.Object))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(requeueAfter).To(Equal(time.Duration(0)))
+			Expect(requeueAfter).To(Equal(syncPeriod))
 		})
 
 		It("should update the PublicIPAddress object status if the IP is not found and the status is already initialized", func() {

--- a/pkg/controller/azure/publicipaddress/add.go
+++ b/pkg/controller/azure/publicipaddress/add.go
@@ -45,6 +45,7 @@ var (
 	DefaultAddOptions = AddOptions{
 		Config: config.AzureOrphanedPublicIPRemedyConfiguration{
 			RequeueInterval:     metav1.Duration{Duration: 1 * time.Minute},
+			SyncPeriod:          metav1.Duration{Duration: 10 * time.Hour},
 			DeletionGracePeriod: metav1.Duration{Duration: 5 * time.Minute},
 			MaxGetAttempts:      5,
 			MaxCleanAttempts:    5,

--- a/pkg/controller/azure/virtualmachine/actuator_test.go
+++ b/pkg/controller/azure/virtualmachine/actuator_test.go
@@ -52,6 +52,7 @@ var _ = Describe("Actuator", func() {
 		azureVirtualMachineName = "shoot--dev--test-vm1"
 
 		requeueInterval = 1 * time.Second
+		syncPeriod      = 1 * time.Minute
 	)
 
 	var (
@@ -89,6 +90,7 @@ var _ = Describe("Actuator", func() {
 
 		cfg = config.AzureFailedVMRemedyConfiguration{
 			RequeueInterval:    metav1.Duration{Duration: requeueInterval},
+			SyncPeriod:         metav1.Duration{Duration: syncPeriod},
 			MaxGetAttempts:     2,
 			MaxReapplyAttempts: 2,
 		}
@@ -150,7 +152,7 @@ var _ = Describe("Actuator", func() {
 
 			requeueAfter, err := actuator.CreateOrUpdate(ctx, vm.DeepCopyObject().(client.Object))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(requeueAfter).To(Equal(time.Duration(0)))
+			Expect(requeueAfter).To(Equal(syncPeriod))
 		})
 
 		It("should not update the VirtualMachine object status if the VM is not found", func() {
@@ -174,7 +176,7 @@ var _ = Describe("Actuator", func() {
 
 			requeueAfter, err := actuator.CreateOrUpdate(ctx, vmWithStatus.DeepCopyObject().(client.Object))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(requeueAfter).To(Equal(time.Duration(0)))
+			Expect(requeueAfter).To(Equal(syncPeriod))
 		})
 
 		It("should update the VirtualMachine object status if the VM is not found and the status is already initialized", func() {
@@ -211,7 +213,7 @@ var _ = Describe("Actuator", func() {
 
 			requeueAfter, err := actuator.CreateOrUpdate(ctx, vm.DeepCopyObject().(client.Object))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(requeueAfter).To(Equal(time.Duration(0)))
+			Expect(requeueAfter).To(Equal(syncPeriod))
 		})
 
 		It("should fail if getting the Azure VM fails", func() {
@@ -305,7 +307,7 @@ var _ = Describe("Actuator", func() {
 
 			requeueAfter, err := actuator.CreateOrUpdate(ctx, vmWithFailedOps.DeepCopyObject().(client.Object))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(requeueAfter).To(Equal(time.Duration(0)))
+			Expect(requeueAfter).To(Equal(syncPeriod))
 		})
 
 		It("should clear failed operations if reapplying the Azure VM eventually succeeds", func() {
@@ -334,7 +336,7 @@ var _ = Describe("Actuator", func() {
 
 			requeueAfter, err := actuator.CreateOrUpdate(ctx, vmWithFailedOps.DeepCopyObject().(client.Object))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(requeueAfter).To(Equal(time.Duration(0)))
+			Expect(requeueAfter).To(Equal(syncPeriod))
 		})
 	})
 

--- a/pkg/controller/azure/virtualmachine/add.go
+++ b/pkg/controller/azure/virtualmachine/add.go
@@ -45,6 +45,7 @@ var (
 	DefaultAddOptions = AddOptions{
 		Config: config.AzureFailedVMRemedyConfiguration{
 			RequeueInterval:    metav1.Duration{Duration: 1 * time.Minute},
+			SyncPeriod:         metav1.Duration{Duration: 2 * time.Hour},
 			MaxGetAttempts:     5,
 			MaxReapplyAttempts: 5,
 		},

--- a/pkg/controller/reconciler.go
+++ b/pkg/controller/reconciler.go
@@ -118,6 +118,7 @@ func (r *reconciler) createOrUpdate(ctx context.Context, obj client.Object, logg
 		if err := controllerutils.RemoveFinalizer(ctx, r.reader, r.client, obj, r.finalizerName); err != nil {
 			return reconcile.Result{}, errors.Wrap(err, "could not remove finalizer")
 		}
+		return reconcile.Result{}, nil
 	}
 
 	if requeueAfter != time.Duration(0) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `SyncPeriod` configuration option for both remedies to to specify the minimum frequency at which `PublicIPAddress` and `VirtualMachine` resources will be reconciled. It defaults to 10h and 2h respectively.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Based on #38, in draft until that one is merged.

**Release note**:

```improvement operator
It is now possible to specify the minimum frequency at which `PublicIPAddress` and `VirtualMachine` resources will be reconciled via the `SyncPeriod` options. By default, these are set to 10 hours and 2 hours respectively.
```
