### PR TITLE
Update CRDs to apiextensions.k8s.io/v1

### DIFF
--- a/example/20-crd-publicipaddress.yaml
+++ b/example/20-crd-publicipaddress.yaml
@@ -1,21 +1,108 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
   name: publicipaddresses.azure.remedy.gardener.cloud
 spec:
   group: azure.remedy.gardener.cloud
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-  version: v1alpha1
-  scope: Namespaced
   names:
-    plural: publicipaddresses
-    singular: publicipaddress
     kind: PublicIPAddress
+    listKind: PublicIPAddressList
+    plural: publicipaddresses
     shortNames:
     - pubip
-  subresources:
-    status: {}
+    singular: publicipaddress
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PublicIPAddress represents an Azure public IP address.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PublicIPAddressSpec represents the spec of an Azure public
+              IP address.
+            properties:
+              ipAddress:
+                description: IPAddres is the actual IP address of the public IP address
+                  resource in Azure.
+                type: string
+            required:
+            - ipAddress
+            type: object
+          status:
+            description: PublicIPAddressStatus represents the status of an Azure public
+              IP address.
+            properties:
+              exists:
+                description: Exists specifies whether the public IP address resource
+                  exists or not.
+                type: boolean
+              failedOperations:
+                description: FailedOperations is a list of all failed operations on
+                  the virtual machine resource in Azure.
+                items:
+                  description: FailedOperation describes a failed Azure operation
+                    that has been attempted a certain number of times.
+                  properties:
+                    attempts:
+                      description: Attempts is the number of times the operation was
+                        attempted so far.
+                      type: integer
+                    errorMessage:
+                      description: ErrorMessage is a the error message from the last
+                        operation failure.
+                      type: string
+                    timestamp:
+                      description: Timestamp is the timestamp of the last operation
+                        failure.
+                      format: date-time
+                      type: string
+                    type:
+                      description: Type is the operation type.
+                      enum:
+                      - GetPublicIPAddress
+                      - CleanPublicIPAddress
+                      - GetVirtualMachine
+                      - ReapplyVirtualMachine
+                      type: string
+                  required:
+                  - attempts
+                  - errorMessage
+                  - timestamp
+                  - type
+                  type: object
+                type: array
+              id:
+                description: ID is the id of the public IP address resource in Azure.
+                type: string
+              name:
+                description: Name is the name of the public IP address resource in
+                  Azure.
+                type: string
+              provisioningState:
+                description: ProvisioningState is the provisioning state of the public
+                  IP address resource in Azure.
+                type: string
+            required:
+            - exists
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/example/20-crd-virtualmachine.yaml
+++ b/example/20-crd-virtualmachine.yaml
@@ -1,21 +1,117 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
   name: virtualmachines.azure.remedy.gardener.cloud
 spec:
   group: azure.remedy.gardener.cloud
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-  version: v1alpha1
-  scope: Namespaced
   names:
-    plural: virtualmachines
-    singular: virtualmachine
     kind: VirtualMachine
+    listKind: VirtualMachineList
+    plural: virtualmachines
     shortNames:
     - vm
-  subresources:
-    status: {}
+    singular: virtualmachine
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VirtualMachine represents an Azure virtual machine.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VirtualMachineSpec represents the spec of an Azure virtual
+              machine.
+            properties:
+              hostname:
+                description: Hostname is the hostname of the Kubernetes node for this
+                  virtual machine.
+                type: string
+              notReadyOrUnreachable:
+                description: NotReadyOrUnreachable is whether the Kubernetes node
+                  for this virtual machine is either not ready or unreachable.
+                type: boolean
+              providerID:
+                description: ProviderID is the provider ID of the Kubernetes node
+                  for this virtual machine.
+                type: string
+            required:
+            - hostname
+            - notReadyOrUnreachable
+            - providerID
+            type: object
+          status:
+            description: VirtualMachineStatus represents the status of an Azure virtual
+              machine.
+            properties:
+              exists:
+                description: Exists specifies whether the virtual machine resource
+                  exists or not.
+                type: boolean
+              failedOperations:
+                description: FailedOperations is a list of all failed operations on
+                  the virtual machine resource in Azure.
+                items:
+                  description: FailedOperation describes a failed Azure operation
+                    that has been attempted a certain number of times.
+                  properties:
+                    attempts:
+                      description: Attempts is the number of times the operation was
+                        attempted so far.
+                      type: integer
+                    errorMessage:
+                      description: ErrorMessage is a the error message from the last
+                        operation failure.
+                      type: string
+                    timestamp:
+                      description: Timestamp is the timestamp of the last operation
+                        failure.
+                      format: date-time
+                      type: string
+                    type:
+                      description: Type is the operation type.
+                      enum:
+                      - GetPublicIPAddress
+                      - CleanPublicIPAddress
+                      - GetVirtualMachine
+                      - ReapplyVirtualMachine
+                      type: string
+                  required:
+                  - attempts
+                  - errorMessage
+                  - timestamp
+                  - type
+                  type: object
+                type: array
+              id:
+                description: ID is the id of the virtual machine resource in Azure.
+                type: string
+              name:
+                description: Name is the name of the virtual machine resource in Azure.
+                type: string
+              provisioningState:
+                description: ProvisioningState is the provisioning state of the virtual
+                  machine resource in Azure.
+                type: string
+            required:
+            - exists
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/pkg/apis/azure/v1alpha1/types_common.go
+++ b/pkg/apis/azure/v1alpha1/types_common.go
@@ -17,6 +17,7 @@ package v1alpha1
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // OperationType is a string alias.
+// +kubebuilder:validation:Enum=GetPublicIPAddress;CleanPublicIPAddress;GetVirtualMachine;ReapplyVirtualMachine
 type OperationType string
 
 // Operation types

--- a/pkg/apis/azure/v1alpha1/types_publicipaddress.go
+++ b/pkg/apis/azure/v1alpha1/types_publicipaddress.go
@@ -20,6 +20,9 @@ import (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:shortName=pubip
+// +kubebuilder:subresource:status
 
 // PublicIPAddress represents an Azure public IP address.
 type PublicIPAddress struct {
@@ -51,6 +54,7 @@ type PublicIPAddressStatus struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:object:root=true
 
 // PublicIPAddressList contains a list of PublicIPAddress.
 type PublicIPAddressList struct {

--- a/pkg/apis/azure/v1alpha1/types_virtualmachine.go
+++ b/pkg/apis/azure/v1alpha1/types_virtualmachine.go
@@ -20,6 +20,9 @@ import (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:shortName=vm
+// +kubebuilder:subresource:status
 
 // VirtualMachine represents an Azure virtual machine.
 type VirtualMachine struct {
@@ -55,6 +58,7 @@ type VirtualMachineStatus struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:object:root=true
 
 // VirtualMachineList contains a list of VirtualMachine.
 type VirtualMachineList struct {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement
/platform azure

**What this PR does / why we need it**:
This PR adds example CRDs in version `apiextensions.k8s.io/v1`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Example CRDs (`example/20-crd-*`) have been update to version `apiextensions.k8s.io/v1`.
```
