### PR TITLE
Allow testshoots to be customized with SHOOT_ANNOTATIONS and ALLOW_PRIVILEGED_CONTAINERS

### DIFF
--- a/.ci/testruns/default/templates/testrun.yaml
+++ b/.ci/testruns/default/templates/testrun.yaml
@@ -106,6 +106,16 @@ spec:
     definition:
       name: create-shoot
       config:
+      {{- if  hasKey .Values.shoot "allowPrivilegedContainers" }}
+      - name: ALLOW_PRIVILEGED_CONTAINERS
+        type: env
+        value: "{{ .Values.shoot.allowPrivilegedContainers }}"
+      {{- end}}
+      {{- if  hasKey .Values.shoot "shootAnnotations" }}
+      - name: SHOOT_ANNOTATIONS
+        type: env
+        value: "{{ .Values.shoot.shootAnnotations }}"
+      {{- end}}
       - name: PROVIDER_TYPE
         type: env
         value: {{ .Values.shoot.cloudprovider }}


### PR DESCRIPTION
Adds two options that are generated by the testmachinery's testrunner to the resp. TestRun charts.
This way the flavor can be used to customize the created shoots with either annotations or by disallowing privileged containers.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
