### PR TITLE
Cleanup integration test leftovers

### DIFF
--- a/.ci/integration_test.py
+++ b/.ci/integration_test.py
@@ -27,6 +27,7 @@ import pubip_remedy_test as pubip_test # noqa
 # TODO: failed_vm_test fails on newer Azure, and it's not clear how to fix it since it was based on
 # some weird Azure behavior that was meanwhile patched.
 # import failed_vm_test as vm_test # noqa
+import cleanup as test_cleanup # noqa
 
 HELM_CHART_NAME = 'remedy-controller-azure'
 HELM_CHART_DEPLOYMENT_NAMESPACE = 'default'
@@ -109,6 +110,11 @@ def main():
             kubernetes_config,
             HELM_CHART_DEPLOYMENT_NAMESPACE,
             HELM_CHART_NAME,
+        )
+        test_cleanup.cleanup(
+            path_to_credentials_file=credentials_path,
+            path_to_kubeconfig=kubeconfig_path,
+            test_namespace=HELM_CHART_DEPLOYMENT_NAMESPACE,
         )
     if not pubip_test_ok: # or not vm_test_ok:
         exit(1)

--- a/Makefile
+++ b/Makefile
@@ -144,3 +144,7 @@ failed-vm-test:
 	test -n $(WORKER_GROUP) # WORKER_GROUP must be given
 	@. $(REPO_ROOT)/.env/bin/activate && python3 $(REPO_ROOT)/test/failed_vm_test.py --credentials-path "$(REPO_ROOT)/dev/credentials.yaml" --fail-worker-group-name $(WORKER_GROUP)
 
+.PHONY: test-cleanup
+test-cleanup:
+	@. $(REPO_ROOT)/.env/bin/activate && python3 $(REPO_ROOT)/test/cleanup.py --credentials-path "$(REPO_ROOT)/dev/credentials.yaml"
+

--- a/test/cleanup.py
+++ b/test/cleanup.py
@@ -1,0 +1,70 @@
+import argparse
+import os
+
+import test_util
+
+TEST_NAMESPACE = "kube-system"
+
+
+def cleanup(
+    path_to_credentials_file: str,
+    path_to_kubeconfig: str,
+    test_namespace: str = TEST_NAMESPACE,
+):
+    k8s_helper, ip_helper, lb_helper = test_util._initialize_test_helpers(
+        path_to_credentials_file=path_to_credentials_file,
+        path_to_kubeconfig=path_to_kubeconfig,
+    )
+    print('Removing leftover publicipaddresses')
+    k8s_helper.cleanup_publicip_custom_objects(namespace=test_namespace)
+    print('Removing leftover virtualmachines')
+    k8s_helper.cleanup_vm_custom_objects(namespace=test_namespace)
+    print('Removing service finalizers')
+    k8s_helper.remove_service_finalizers()
+    print('Removing node finalizers')
+    k8s_helper.remove_node_finalizers()
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        '--kubeconfig-path',
+        dest='kubeconfig_path',
+        type=str,
+        help='Path to kubeconfig file. Will try to use $KUBECONFIG env var if not given.',
+        required=False
+    )
+    parser.add_argument(
+        '--credentials-path',
+        dest='credentials_path',
+        type=str,
+        help='Path to credentials file.',
+        required=True
+    )
+    parser.add_argument(
+        '--test-namespace',
+        dest='test_namespace',
+        type=str,
+        help='Namespace in the cluster in which the test will create publicipaddress objects.',
+        default=TEST_NAMESPACE,
+    )
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = _parse_args()
+
+    if not args.kubeconfig_path:
+        print("'--kubeconfig-path' not set, defaulting to $KUBECONFIG env var")
+        if 'KUBECONFIG' not in os.environ:
+            print("'KUBECONFIG' env var must be set.")
+            exit(1)
+        path_to_kubeconfig = os.environ['KUBECONFIG']
+    else:
+        path_to_kubeconfig = args.kubeconfig_path
+
+    cleanup(
+        path_to_kubeconfig=path_to_kubeconfig,
+        path_to_credentials_file=args.credentials_path,
+        test_namespace=args.test_namespace,
+    )

--- a/test/pubip_remedy_test.py
+++ b/test/pubip_remedy_test.py
@@ -42,7 +42,7 @@ def run_test(
         print('Found leaked resources from previous run. Cleaning up')
         # ensure that there are no leftover resources
         k8s_helper.cleanup_test_services()
-        k8s_helper.cleanup_publicip_custom_objects()
+        k8s_helper.cleanup_publicip_custom_objects(namespace=test_namespace)
         lb_helper.remove_orphaned_rules()
         ip_helper.clean_up_public_ips()
 
@@ -134,7 +134,7 @@ def run_test(
         print('Found leaked resources. Cleaning up and failing.')
         # ensure that there are no leftover resources
         k8s_helper.cleanup_test_services()
-        k8s_helper.cleanup_publicip_custom_objects()
+        k8s_helper.cleanup_publicip_custom_objects(namespace=test_namespace)
         lb_helper.remove_orphaned_rules()
         ip_helper.clean_up_public_ips()
         return False


### PR DESCRIPTION
**How to categorize this PR?**

/area testing
/kind enhancement
/platform azure

**What this PR does / why we need it**:
Adds a new test module to cleanup integration test leftovers as well as all finalizers from services and nodes, together with its respective `make` targets and `.ci` integration.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
NONE
```
