### PR TITLE
Change base image from alpine to distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,18 @@ COPY . .
 RUN make install
 
 ############# base image
-FROM alpine:3.16.2 AS base
+FROM gcr.io/distroless/static-debian11:nonroot AS base
 
 ############# remedy-controller-azure
 FROM base AS remedy-controller-azure
+WORKDIR /
 
-#COPY charts /charts
 COPY --from=builder /go/bin/remedy-controller-azure /remedy-controller-azure
 ENTRYPOINT ["/remedy-controller-azure"]
 
 ############# remedy-applier-azure
 FROM base AS remedy-applier-azure
+WORKDIR /
 
 COPY --from=builder /go/bin/remedy-applier-azure /remedy-applier-azure
 ENTRYPOINT ["/remedy-applier-azure"]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/platform azure

**What this PR does / why we need it**:
This PR changes the base image for `remedy-controller` container from `alpine` to [distroless](https://github.com/GoogleContainerTools/distroless). The process will now use a non root user for its execution. This will reduce the attack surface of the image.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `remedy-controller` container now uses `distroless` instead of `alpine` as a base image.
```
