### PR TITLE
Disable unused health bind address

### DIFF
--- a/cmd/remedy-controller-azure/app/app.go
+++ b/cmd/remedy-controller-azure/app/app.go
@@ -50,15 +50,11 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 				LeaderElectionID:        controllercmd.LeaderElectionNameID(Name),
 				LeaderElectionNamespace: os.Getenv("LEADER_ELECTION_NAMESPACE"),
 			},
-			MetricsBindAddress: ":6000",
-			Namespace:          "kube-system",
+			Namespace: "kube-system",
 		}
 
 		targetRestOpts = &controllercmd.RESTOptions{}
-		targetMgrOpts  = &cmd.ManagerOptions{
-			ManagerOptions:     controllercmd.ManagerOptions{},
-			MetricsBindAddress: ":6001",
-		}
+		targetMgrOpts  = &cmd.ManagerOptions{}
 
 		// options for the publicipaddress controller
 		publicIPAddressCtrlOpts = &controllercmd.ControllerOptions{

--- a/pkg/cmd/manager_options.go
+++ b/pkg/cmd/manager_options.go
@@ -31,9 +31,6 @@ type ManagerOptions struct {
 	// Namespace is the namespace to watch objects in.
 	// If not specified, defaults to all namespaces.
 	Namespace string
-	// MetricsBindAddress is the TCP address that the controller should bind to for serving prometheus metrics.
-	// It can be set to "0" to disable the metrics serving.
-	MetricsBindAddress string
 
 	config *ManagerConfig
 }
@@ -50,9 +47,8 @@ func (m *ManagerOptions) Complete() error {
 		return err
 	}
 	m.config = &ManagerConfig{
-		ManagerConfig:      *m.ManagerOptions.Completed(),
-		Namespace:          m.Namespace,
-		MetricsBindAddress: m.MetricsBindAddress,
+		ManagerConfig: *m.ManagerOptions.Completed(),
+		Namespace:     m.Namespace,
 	}
 	return nil
 }
@@ -68,16 +64,14 @@ type ManagerConfig struct {
 	// Namespace is the namespace to watch objects in.
 	// If not specified, defaults to all namespaces.
 	Namespace string
-	// MetricsBindAddress is the TCP address that the controller should bind to for serving prometheus metrics.
-	// It can be set to "0" to disable the metrics serving.
-	MetricsBindAddress string
 }
 
 // Apply sets the values of this ManagerConfig in the given manager.Options.
 func (c *ManagerConfig) Apply(opts *manager.Options) {
 	c.ManagerConfig.Apply(opts)
 	opts.Namespace = c.Namespace
-	opts.MetricsBindAddress = c.MetricsBindAddress
+	// disable health probe as not used but defaulted to the same port twice
+	opts.HealthProbeBindAddress = ""
 }
 
 // Options initializes empty manager.Options, applies the set values and returns it.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform azure

**What this PR does / why we need it**:
The remedy-controller creates two managers for control-plane and shoot. Both are using metrics and health probe ports with hard coded default values. This means the health-probe port is opened using the default port 8081 twice, which is not possible. As there is no health probe defined, the easiest solution is to disable the health-probe port for both managers.
Additionally, the `MetricsBindAddress` was removed from the manager config/options, as it is already provided by the underlying manager options from the `controller/cmd` package of gardener. The current implementation was not correct, as it does not respect the `--metrics-bind-address` command line option.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Disable unused health bind address
```
