### PR TITLE
switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,16 +1,22 @@
 remedy-controller:
+  base_definition:
+    traits:
+      version: ~
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
+
   jobs:
     force-release:
       traits:
         version:
           preprocess: "finalize"
           inject_effective_version: True
-        component_descriptor: ~
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         publish:
           dockerimages:
             remedy-controller-image:
-              registry: "gcr-readwrite"
-              image: "eu.gcr.io/gardener-project/gardener/remedy-controller/remedy-controller-azure"
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/remedy-controller/remedy-controller-azure
               dockerfile: "Dockerfile"
               target: remedy-controller-azure
               tag_as_latest: True
@@ -31,8 +37,7 @@ remedy-controller:
         publish:
           dockerimages:
             remedy-controller-image:
-              registry: "gcr-readwrite"
-              image: "eu.gcr.io/gardener-project/gardener/remedy-controller/remedy-controller-azure"
+              image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/remedy-controller/remedy-controller-azure
               dockerfile: "Dockerfile"
               target: remedy-controller-azure
     pull-request:
@@ -54,11 +59,11 @@ remedy-controller:
       traits:
         version:
           inject_effective_version: True
-        component_descriptor: ~
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         publish:
           dockerimages:
             remedy-controller-image:
-              registry: "gcr-readwrite"
-              image: "eu.gcr.io/gardener-project/gardener/remedy-controller/remedy-controller-azure"
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/remedy-controller/remedy-controller-azure
               dockerfile: "Dockerfile"
               target: remedy-controller-azure

--- a/.test-defs/integration-test.yaml
+++ b/.test-defs/integration-test.yaml
@@ -21,8 +21,6 @@ spec:
   # Arguments to the entrypoint. The docker image's CMD is used if this is not provided.
   args: [".ci/integration_test.sh"]
 
-  # image: eu.gcr.io/gardener-project/cc/job-image-golang:0.12.0
-
   # optional; Configuration of a TestDefinition.
   # Environment Variables can be configured per TestDefinition
   # by specifying the varibale's name and a value, secret or configmap.

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@
 
 NAME                        := remedy-controller
 APPLIER_NAME                := remedy-applier
-REGISTRY                    := eu.gcr.io/gardener-project/gardener/remedy-controller
-IMAGE_PREFIX                := $(REGISTRY)
+REGISTRY                    := europe-docker.pkg.dev/gardener-project/public
+IMAGE_PREFIX                := $(REGISTRY)/gardener/remedy-controller
 REPO_ROOT                   := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 VERSION                     := $(shell cat "$(REPO_ROOT)/VERSION")
 LD_FLAGS                    := "-w -X github.com/gardener/$(NAME)/pkg/version.Version=$(VERSION) -X github.com/gardener/$(NAME)/pkg/version.GitCommit=$(shell git rev-parse --verify HEAD) -X github.com/gardener/$(NAME)/pkg/version.BuildDate=$(shell date --rfc-3339=seconds | sed 's/ /T/')"

--- a/charts/remedy-controller-azure/values.yaml
+++ b/charts/remedy-controller-azure/values.yaml
@@ -1,6 +1,6 @@
 replicas: 1
 image:
-  repository: eu.gcr.io/gardener-project/gardener/remedy-controller/remedy-controller-azure
+  repository: europe-docker.pkg.dev/gardener-project/public/gardener/remedy-controller/remedy-controller-azure
   tag: latest
   pullPolicy: IfNotPresent
 resources:


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
